### PR TITLE
fix: resolve documentation 404s and CI failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: dist/*

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/mne-denoise.svg)](https://pypi.org/project/mne-denoise/)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Code style: ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://mne-tools.github.io/mne-denoise/)
+[![Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://mne.tools/mne-denoise/)
 [![Downloads](https://pepy.tech/badge/mne-denoise)](https://pepy.tech/project/mne-denoise)
 
 **Advanced denoising algorithms for M/EEG data in MNE-Python.**
@@ -116,11 +116,11 @@ print(f"Detected line frequency: {zapline_plus.detected_freq_} Hz")
 
 ## Documentation
 
-Full documentation is available at **[mne-tools.github.io/mne-denoise](https://mne-tools.github.io/mne-denoise/)**.
+Full documentation is available at **[mne.tools/mne-denoise](https://mne.tools/mne-denoise/)**.
 
-- [Getting Started Guide](https://mne-tools.github.io/mne-denoise/getting-started.html)
-- [API Reference](https://mne-tools.github.io/mne-denoise/api.html)
-- [Example Gallery](https://mne-tools.github.io/mne-denoise/auto_examples/index.html)
+- [Getting Started Guide](https://mne.tools/mne-denoise/getting-started.html)
+- [API Reference](https://mne.tools/mne-denoise/api.html)
+- [Example Gallery](https://mne.tools/mne-denoise/auto_examples/index.html)
 
 ## 🏗️ Architecture
 

--- a/docs/changes/devel/33.bugfix.rst
+++ b/docs/changes/devel/33.bugfix.rst
@@ -1,0 +1,1 @@
+Fix 404 documentation errors and CI failures by updating project URLs to ``mne.tools`` and bumping the MNE requirement to >=1.9.0 (fixing compatibility with SciPy 1.15.0). Also bumped ``softprops/action-gh-release`` to v3.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Medical Science Apps.",
 ]
 dependencies = [
-  "mne>=1.8",
+  "mne>=1.9",
   "numpy>=1.22",
   "scipy>=1.8",
   "matplotlib>=3.5",
@@ -54,7 +54,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/mne-tools/mne-denoise"
-Documentation = "https://mne-tools.github.io/mne-denoise/"
+Documentation = "https://mne.tools/mne-denoise/"
 Repository = "https://github.com/mne-tools/mne-denoise"
 Issues = "https://github.com/mne-tools/mne-denoise/issues"
 Changelog = "https://github.com/mne-tools/mne-denoise/blob/main/CHANGELOG.md"
@@ -76,7 +76,7 @@ dev = [
   "towncrier",
 ]
 docs = [
-  "mne>=1.8",
+  "mne>=1.9",
   "numpydoc>=1.6.0",
   "pydata-sphinx-theme>=0.15.2",
   "sphinx>=7.2.0",


### PR DESCRIPTION
- Bump MNE to >=1.9.0 to fix SciPy 1.15.0 compatibility (sph_harm)
- Update documentation URLs to mne.tools
- Bump softprops/action-gh-release to v3
- Add towncrier news fragment