### PR TITLE
docs: describe every module, and fix four broken README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,12 +167,11 @@ epochs = mne.read_epochs("sample-epo.fif")
 dss = DSS(bias=AverageBias(axis="epochs"), n_components=5)
 dss.fit(epochs)
 
-sources = dss.transform(epochs)          # component time courses
-pattern = dss.patterns_[:, 0]            # topography of component 1
+sources = dss.transform(epochs)  # component time courses
+pattern = dss.patterns_[:, 0]  # topography of component 1
 
 # To get denoised sensor-space data instead, set return_type on the estimator
-dss_sensor = DSS(bias=AverageBias(axis="epochs"), n_components=5,
-                 return_type="epochs")
+dss_sensor = DSS(bias=AverageBias(axis="epochs"), n_components=5, return_type="epochs")
 epochs_clean = dss_sensor.fit_transform(epochs)
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,31 +9,91 @@
 [![Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://mne.tools/mne-denoise/)
 [![Downloads](https://pepy.tech/badge/mne-denoise)](https://pepy.tech/project/mne-denoise)
 
-**Advanced denoising algorithms for M/EEG data in MNE-Python.**
+**Artifact removal for M/EEG, matched to the structure of the contamination.**
 
-`mne-denoise` provides powerful signal denoising techniques for the MNE-Python ecosystem, including **Denoising Source Separation (DSS)** and **ZapLine** algorithms. These methods excel at extracting signals of interest by exploiting data structure rather than just variance.
+There is no universally correct denoiser. Line noise, transient movement bursts,
+reference-correlated artifacts and "enhance the response I care about" are
+different problems, and they need different information to solve. `mne-denoise`
+implements each as a scikit-learn-style estimator that works directly on MNE
+objects, and — just as importantly — leaves behind a fitted state you can
+inspect to check what it actually did.
+
+## Choosing a method
+
+| Your problem | Method | What information it uses |
+|---|---|---|
+| Power-line noise, possibly non-stationary | [`ZapLine`](#zapline--power-line-noise) | narrowband spatial structure at the line frequency |
+| Line noise, conservative and phase-preserving | [`SpectrumInterpolation`](#spectrum-interpolation) | the spectral neighbourhood of the peak |
+| Large transient / movement artifacts | [`ASR`](#asr--transient-artifacts) and variants | abnormal covariance relative to a clean baseline |
+| You recorded noise reference channels | [`ICanClean`](#icanclean--reference-based-cleaning) | correlation between scalp and reference channels |
+| Channel-specific sensor noise | [`SNS`](#sns--sensor-noise-suppression) | what neighbouring sensors agree on |
+| Enhance a response you can define | [`DSS`](#dss--enhancing-a-target-response) | a bias you declare (trial average, band, period…) |
 
 ## Features
 
-### DSS Module
+### ASR — transient artifacts
 
-- **Linear DSS**: Extract components based on reproducibility across trials or characteristic frequencies
-- **Iterative DSS**: Powerful nonlinear separation for complex non-Gaussian sources
-- **20+ Pluggable Denoisers**: Spectral, temporal, periodic, and ICA-style bias functions
-- **Specialized Variants**: TSR, SSVEP enhancement, narrowband oscillation extraction
+Artifact Subspace Reconstruction: calibrate a clean-covariance baseline, then
+reconstruct segments whose variance leaves that subspace.
 
-### ZapLine Module
+- **`ASR`** — the standard algorithm, with a Riemannian-robust calibration
+  backend via `method="riemannian_windowed"`
+- **`AdaptiveASR`** — tracks non-stationarity; supports streaming through
+  `fit()` / `partial_fit()` / `transform()`
+- **`JugglerASR`** — sample-wise calibration for extreme-motion recordings where
+  the window-based clean-data selector collapses
+- **`GuidedASR`** — experimental research prototype, not a validated method
+- Validated against MATLAB reference implementations by parity fixtures under
+  `tests/parity/`
 
-- **ZapLine**: Efficient removal of power line noise (50/60 Hz) and harmonics
-- **ZapLine-plus**: Fully adaptive mode with automatic frequency detection
-- **Per-chunk Processing**: Handles non-stationary noise characteristics
-- **Quality Assurance**: Built-in spectral checks to prevent over-cleaning
+### DSS — enhancing a target response
+
+Denoising Source Separation finds spatial filters that maximise a property you
+declare, rather than variance.
+
+- **Linear and iterative DSS**, with reconstruction back into sensor space
+- **20+ pluggable bias functions**: trial-average, spectral, temporal, periodic,
+  spectrogram and ICA-style
+- **Specialized variants**: time-shift repeatability, SSVEP, narrowband
+
+### ZapLine — power-line noise
+
+- **`ZapLine`** — removes 50/60 Hz and harmonics by spatial filtering, keeping
+  the surrounding spectrum intact
+- **ZapLine-plus** via `adaptive=True` — automatic frequency detection and
+  per-chunk processing for non-stationary contamination
+- Built-in spectral checks intended to guard against over-cleaning
+
+### iCanClean — reference-based cleaning
+
+- Removes subspaces shared between scalp channels and dedicated reference
+  channels using canonical correlation analysis
+- `global`, `sliding`, `calibrated` and `hybrid` operating modes
+- Adaptive thresholding with a cap on the fraction of components removed
+
+### Spectrum interpolation
+
+- Replaces amplitude in a narrow band around the line frequency and its
+  harmonics **while preserving phase**
+- Controls for frequency, harmonics, bandwidth and neighbour width
+
+### SNS — sensor noise suppression
+
+- Reconstructs each sensor from the sensors that agree with it, removing
+  channel-specific noise
+
+### Quality assurance
+
+`mne_denoise.qa` provides endpoints for both halves of the question a denoiser
+has to answer: did contamination go down, and did neural signal survive —
+peak-to-surround ratios, broadband distortion, variance removed, and more.
 
 ### Integration
 
-- **MNE-Python**: Works directly with `Raw`, `Epochs`, and `Evoked` objects or `numpy` arrays.
-- **Scikit-Learn API**: Standard `fit()`, `transform()`, `fit_transform()` interface
-- **Visualization**: Built-in plotting for components and cleaning results
+- **MNE-Python**: works with `Raw`, `Epochs` and `Evoked`, or plain NumPy arrays
+- **Scikit-learn API**: `fit()`, `transform()`, `fit_transform()`
+- **Visualization**: `mne_denoise.viz` for components, spectra, repair
+  timelines and calibration diagnostics
 
 ## Installation
 
@@ -53,65 +113,89 @@ pip install -e ".[dev]"
 
 ## Quick Start
 
-### DSS: Enhancing Evoked Responses
-
-DSS finds spatial filters that maximize the ratio of reproducible (evoked) to total power:
-
-```python
-import mne
-from mne_denoise.dss import DSS, AverageBias
-
-# Load your epoched data
-epochs = mne.read_epochs("sample-epo.fif")
-
-# Create DSS with trial-average bias
-dss = DSS(bias=AverageBias(), n_components=5)
-dss.fit(epochs)
-
-# Option 1: Extract source time courses
-sources = dss.transform(epochs)
-
-# Option 2: Reconstruct denoised sensor data
-cleaned_epochs = dss.transform(epochs, return_type="epochs")
-```
-
-### DSS: Extracting Oscillations
-
-Isolate specific frequency bands (e.g., alpha rhythm):
-
-```python
-from mne_denoise.dss import DSS, BandpassBias
-
-# Create bandpass bias for alpha (8-12 Hz)
-bias = BandpassBias(sfreq=epochs.info["sfreq"], freq=10, bandwidth=4)
-
-dss = DSS(bias=bias, n_components=3)
-alpha_sources = dss.fit_transform(epochs)
-```
-
-### ZapLine: Removing Line Noise
-
-Remove 50/60 Hz power line artifacts:
+### Removing line noise
 
 ```python
 import mne
 from mne_denoise.zapline import ZapLine
 
-# Load continuous data
 raw = mne.io.read_raw_fif("sample-raw.fif", preload=True)
 
-# Standard mode: specify line frequency
+# Standard mode: you know the line frequency
 zapline = ZapLine(sfreq=raw.info["sfreq"], line_freq=50.0)
-cleaned_data = zapline.fit_transform(raw)
+raw_clean = zapline.fit_transform(raw)
+print(f"Removed {zapline.n_removed_} components")
 
-# Adaptive mode: automatic detection and per-chunk processing
-zapline_plus = ZapLine(
+# ZapLine-plus: detect the frequency and adapt per chunk.
+# Adaptive mode calibrates and cleans together, so use fit_transform.
+zapline_plus = ZapLine(sfreq=raw.info["sfreq"], line_freq=None, adaptive=True)
+raw_clean = zapline_plus.fit_transform(raw)
+
+results = zapline_plus.adaptive_results_
+print(f"Detected {results['line_freq']} Hz over {len(results['chunk_info'])} chunks")
+```
+
+### Repairing transient artifacts
+
+```python
+from mne_denoise.asr import ASR
+
+# ASR expects high-pass filtered data
+raw.filter(1.0, None)
+
+asr = ASR(cutoff=20.0)
+raw_clean = asr.fit_transform(raw)
+
+# What did it actually do?
+print(f"{asr.sample_mask_.mean():.1%} of samples repaired")
+print(f"calibrated on {asr.calibration_info_['calibration_samples']} samples")
+```
+
+The `cutoff` default of 20 exists for comparability with reference
+implementations. It is not a universally validated operating point — validate it
+for your recording regime before freezing it.
+
+### Enhancing an evoked response
+
+```python
+import mne
+from mne_denoise.dss import DSS, AverageBias
+
+epochs = mne.read_epochs("sample-epo.fif")
+
+# Bias the decomposition toward what repeats across trials
+dss = DSS(bias=AverageBias(axis="epochs"), n_components=5)
+dss.fit(epochs)
+
+sources = dss.transform(epochs)          # component time courses
+pattern = dss.patterns_[:, 0]            # topography of component 1
+
+# To get denoised sensor-space data instead, set return_type on the estimator
+dss_sensor = DSS(bias=AverageBias(axis="epochs"), n_components=5,
+                 return_type="epochs")
+epochs_clean = dss_sensor.fit_transform(epochs)
+```
+
+### Extracting oscillations
+
+```python
+from mne_denoise.dss import DSS, BandpassBias
+
+bias = BandpassBias(freq_band=(8.0, 12.0), sfreq=epochs.info["sfreq"])
+alpha_sources = DSS(bias=bias, n_components=3).fit_transform(epochs)
+```
+
+### Cleaning with reference channels
+
+```python
+from mne_denoise.icanclean import ICanClean
+
+icc = ICanClean(
     sfreq=raw.info["sfreq"],
-    line_freq=None,  # Auto-detect
-    adaptive=True,
+    ref_channels=[ch for ch in raw.ch_names if ch.startswith("N-")],
 )
-cleaned = zapline_plus.fit_transform(raw)
-print(f"Detected line frequency: {zapline_plus.detected_freq_} Hz")
+raw_clean = icc.fit_transform(raw)
+print(f"removed {icc.n_removed_.mean():.1f} components per window")
 ```
 
 ## Documentation
@@ -119,28 +203,32 @@ print(f"Detected line frequency: {zapline_plus.detected_freq_} Hz")
 Full documentation is available at **[mne.tools/mne-denoise](https://mne.tools/mne-denoise/)**.
 
 - [Getting Started Guide](https://mne.tools/mne-denoise/getting-started.html)
+- [ASR user guide](https://mne.tools/mne-denoise/asr.html)
+- [DSS user guide](https://mne.tools/mne-denoise/dss.html)
 - [API Reference](https://mne.tools/mne-denoise/api.html)
 - [Example Gallery](https://mne.tools/mne-denoise/auto_examples/index.html)
 
-## 🏗️ Architecture
+## Architecture
 
 ```
 mne_denoise/
+├── asr/                    # Artifact Subspace Reconstruction
+│   ├── core.py             # ASR estimator
+│   ├── adaptive.py         # AdaptiveASR (streaming / non-stationary)
+│   ├── juggler.py          # JugglerASR (sample-wise calibration)
+│   └── guided.py           # GuidedASR (experimental)
 ├── dss/                    # Denoising Source Separation
 │   ├── linear.py           # Core DSS algorithm, DSS estimator
 │   ├── nonlinear.py        # Iterative DSS, IterativeDSS estimator
 │   ├── denoisers/          # 20+ pluggable bias functions
-│   │   ├── spectral.py     # BandpassBias, LineNoiseBias
-│   │   ├── temporal.py     # TimeShiftBias, SmoothingBias
-│   │   ├── periodic.py     # CombFilterBias, PeakFilterBias
-│   │   └── ...
-│   └── variants/           # Pre-built applications
-│       ├── tsr.py          # Time-Shift Repeatability
-│       ├── ssvep.py        # SSVEP enhancement
-│       └── narrowband.py   # Oscillation extraction
+│   └── variants/           # TSR, SSVEP, narrowband
 ├── zapline/                # Line noise removal
 │   ├── core.py             # ZapLine estimator
 │   └── adaptive.py         # ZapLine-plus utilities
+├── icanclean/              # Reference-based CCA cleaning
+├── spectrum_interpolation/ # Phase-preserving spectral replacement
+├── sns/                    # Sensor noise suppression
+├── qa.py                   # Artifact and preservation metrics
 └── viz/                    # Visualization tools
 ```
 
@@ -168,6 +256,16 @@ pre-commit install
 
 ## References
 
+### ASR
+
+> Kothe, C. A. E., & Jung, T. P. (2016). Artifact removal techniques with signal reconstruction. _U.S. Patent No. 9,474,467_.
+
+> Chang, C.-Y., Hsu, S.-H., Pion-Tonachini, L., & Jung, T.-P. (2020). Evaluation of Artifact Subspace Reconstruction for Automatic Artifact Components Removal in Multi-Channel EEG Recordings. _IEEE Transactions on Biomedical Engineering_, 67(4), 1114-1121.
+
+> Blum, S., Jacobsen, N. S. J., Bleichner, M. G., & Debener, S. (2019). A Riemannian Modification of Artifact Subspace Reconstruction for EEG Artifact Handling. _Frontiers in Human Neuroscience_, 13, 141.
+
+> Kim, H., Chang, C., Kothe, C., Iversen, J. R., & Miyakoshi, M. (2025). Juggler's ASR: unpacking the principles of artifact subspace reconstruction for revision toward extreme MoBI. _Journal of Neuroscience Methods_, 420, 110465.
+
 ### DSS
 
 > Särelä, J., & Valpola, H. (2005). Denoising source separation. _Journal of Machine Learning Research_, 6, 233-272.
@@ -178,7 +276,15 @@ pre-commit install
 
 > de Cheveigné, A. (2020). ZapLine: A simple and effective method to remove power line artifacts. _NeuroImage_, 207, 116356.
 
-> Klug, M., & Kloosterman, N. A. (2022). Zapline-plus: A completely automatic and highly effective method for removing power line noise. _Human Brain Mapping_, 43(9), 2743-2758.
+> Klug, M., & Kloosterman, N. A. (2022). Zapline-plus: A Zapline extension for automatic and adaptive removal of frequency-specific noise artifacts in M/EEG. _Human Brain Mapping_, 43(9), 2743-2758.
+
+### iCanClean
+
+> Downey, R. J., & Ferris, D. P. (2023). iCanClean Removes Motion, Muscle, Eye, and Line-Noise Artifacts from Phantom EEG. _Sensors_, 23(19), 8214.
+
+### SNS
+
+> de Cheveigné, A., & Simon, J. Z. (2008). Sensor noise suppression. _Journal of Neuroscience Methods_, 168(1), 195-202.
 
 ## License
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,9 +2,38 @@
 mne-denoise
 ===========
 
-`mne-denoise` provides narrow-band artefact suppression routines tailored to
-MNE-Python workflows. The package specializes in Denoising Source Separation (DSS)
-to extract reproducible or rhythmic components while preserving data rank.
+`mne-denoise` provides artifact removal for M/EEG, matched to the structure of
+the contamination. Line noise, transient movement bursts, reference-correlated
+artifacts and target-response enhancement are different problems that need
+different information, so the package implements each as a separate
+scikit-learn-style estimator that operates directly on MNE objects and exposes
+an inspectable fitted state.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 22 44
+
+   * - Your problem
+     - Method
+     - Information it uses
+   * - Power-line noise, possibly non-stationary
+     - :class:`~mne_denoise.zapline.ZapLine`
+     - narrowband spatial structure at the line frequency
+   * - Line noise, conservative and phase-preserving
+     - ``spectrum_interpolation``
+     - the spectral neighbourhood of the peak
+   * - Large transient / movement artifacts
+     - :class:`~mne_denoise.asr.ASR` and variants
+     - abnormal covariance relative to a clean baseline
+   * - Recorded noise reference channels available
+     - :class:`~mne_denoise.icanclean.ICanClean`
+     - correlation between scalp and reference channels
+   * - Channel-specific sensor noise
+     - ``sns``
+     - what neighbouring sensors agree on
+   * - Enhance a response you can define
+     - :class:`~mne_denoise.dss.DSS`
+     - a bias you declare (trial average, band, period, ...)
 
 .. toctree::
    :maxdepth: 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mne-denoise"
 version = "0.0.1"
-description = "Denoising Source Separation (DSS) and ZapLine algorithms for MNE-Python."
+description = "Artifact removal for MNE-Python: ASR, DSS, ZapLine, iCanClean, SNS and spectrum interpolation."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
@@ -22,8 +22,13 @@ keywords = [
   "eeg",
   "meg",
   "denoising",
+  "artifact-removal",
+  "asr",
+  "artifact-subspace-reconstruction",
   "dss",
   "zapline",
+  "icanclean",
+  "line-noise",
   "neuroscience",
   "electrophysiology",
   "signal-processing",


### PR DESCRIPTION
## Why

The code has moved ahead of the public-facing story. `mne_denoise/` ships **asr, dss, icanclean, sns, spectrum_interpolation and zapline**, but:

- the README did not contain the string "ASR" once — for a module with four estimator classes, 38 MATLAB parity fixtures and 15 gallery examples
- `pyproject.toml` still described the project as *"Denoising Source Separation (DSS) and ZapLine algorithms for MNE-Python"*
- `docs/index.rst` opened with *"specializes in Denoising Source Separation (DSS)"*

Counting mentions before this PR: DSS 20, ZapLine 17, **ASR 0, iCanClean 0, spectrum_interpolation 0, SNS 0**.

## What changed

Reframed the README around **choosing a method by contamination structure** — a table mapping problem → method → the information that method uses — and covered all six modules. Same table now opens the docs landing page.

### Four Quick Start examples were broken

These are exactly the lines a new user copy-pastes. Each is now fixed, and **all seven snippets in the README were executed against synthetic data before committing** (7 passed, 0 failed).

| Was | Result | Now |
|---|---|---|
| `zapline_plus.detected_freq_` | `AttributeError` — attribute does not exist | `adaptive_results_["line_freq"]` |
| `dss.transform(epochs, return_type="epochs")` | `TypeError` — `transform` takes only `(self, X)` | `return_type` set on the constructor |
| `BandpassBias(sfreq=..., freq=10, bandwidth=4)` | `TypeError` | `BandpassBias(freq_band=(8.0, 12.0), sfreq=...)` |
| adaptive ZapLine example | implied `fit`/`transform` work | notes that adaptive mode requires `fit_transform` |

Also added `asr`, `artifact-removal`, `icanclean`, `line-noise` to the packaging keywords so the project is findable by what it does.

## Notes

- No library code changes; docs and packaging metadata only.
- The five documentation links in the README currently point at a 404 — the docs site is down for an unrelated reason. That is addressed in a separate PR.