### PR TITLE
ICanClean: restore pseudo-reference mode (pseudo_ref / filter_ref)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **ICanClean pseudo-reference mode** (restores functionality removed in
+  `e38e8f5` without a changelog entry; see issue #68)
+  - `pseudo_ref=True` derives the CCA reference block from the primary
+    channels themselves rather than from physical noise electrodes, for
+    recordings with no dual-layer cap. Implements the pseudo-reference
+    method of Downey & Ferris 2023, *Sensors* 23(19):8214.
+  - `filter_ref=(kind, freqs)` shapes the reference block before CCA:
+    `'notch'` (wide band-stop), `'bp'`, `'hp'`, `'lp'`; zero-phase
+    4th-order Butterworth. Usable on its own to filter physical reference
+    channels.
+  - `ref_channels` is now optional when `pseudo_ref=True`.
+  - `pseudo_ref=True` without `filter_ref` raises: an unfiltered copy of
+    the primary block is perfectly correlated with itself and would remove
+    the entire signal.
+
 ## [0.0.1] - 2026-01-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- **ICanClean pseudo-reference mode** (restores functionality removed in
-  `e38e8f5` without a changelog entry; see issue #68)
-  - `pseudo_ref=True` derives the CCA reference block from the primary
-    channels themselves rather than from physical noise electrodes, for
-    recordings with no dual-layer cap. Implements the pseudo-reference
-    method of Downey & Ferris 2023, *Sensors* 23(19):8214.
-  - `filter_ref=(kind, freqs)` shapes the reference block before CCA:
-    `'notch'` (wide band-stop), `'bp'`, `'hp'`, `'lp'`; zero-phase
-    4th-order Butterworth. Usable on its own to filter physical reference
-    channels.
-  - `ref_channels` is now optional when `pseudo_ref=True`.
-  - `pseudo_ref=True` without `filter_ref` raises: an unfiltered copy of
-    the primary block is perfectly correlated with itself and would remove
-    the entire signal.
-
 ## [0.0.1] - 2026-01-23
 
 ### Added

--- a/docs/changes/devel/74.feature.rst
+++ b/docs/changes/devel/74.feature.rst
@@ -1,8 +1,8 @@
 Added ``pseudo_ref``/``filter_ref`` to :class:`mne_denoise.icanclean.ICanClean`,
 to add the pseudo-reference mode. ``pseudo_ref=True`` derives the CCA reference
-block from the primary channels themselves (a copy filtered with ``filter_ref`` 
-and appended as the reference) the method of Downey & Ferris (2023), 
-*Sensors* 23(19):8214, for recordings with no dual-layer cap; 
+block from the primary channels themselves (a copy filtered with ``filter_ref``
+and appended as the reference) the method of Downey & Ferris (2023),
+*Sensors* 23(19):8214, for recordings with no dual-layer cap;
 ``ref_channels`` must then be left ``None``. ``filter_ref=(btype, freqs)``
 also works standalone to filter real reference channels, via zero-phase 4th-order
 Butterworth. An unfiltered pseudo-reference, a non-positive frequency, or a band

--- a/docs/changes/devel/74.feature.rst
+++ b/docs/changes/devel/74.feature.rst
@@ -1,0 +1,10 @@
+Added ``pseudo_ref``/``filter_ref`` to :class:`mne_denoise.icanclean.ICanClean`,
+to add the pseudo-reference mode. ``pseudo_ref=True`` derives the CCA reference
+block from the primary channels themselves (a copy filtered with ``filter_ref`` 
+and appended as the reference) the method of Downey & Ferris (2023), 
+*Sensors* 23(19):8214, for recordings with no dual-layer cap; 
+``ref_channels`` must then be left ``None``. ``filter_ref=(btype, freqs)``
+also works standalone to filter real reference channels, via zero-phase 4th-order
+Butterworth. An unfiltered pseudo-reference, a non-positive frequency, or a band
+edge at or past Nyquist now raises at construction, rather than silently removing
+the whole signal or failing inside scipy the first time data is transformed.

--- a/docs/changes/devel/74.misc.rst
+++ b/docs/changes/devel/74.misc.rst
@@ -1,0 +1,7 @@
+Added ``mne_denoise._filtering.design_butter_sos``, replacing independently
+hand-rolled Butterworth SOS design in ICanClean, the DSS covariance segmenter,
+ZapLine's cleanline notch fallback, and DSS's ``BandpassBias``. Also removed
+the manual per-epoch ``sosfiltfilt`` loops in ``BandpassBias``, 
+``PeakFilterBias``, and ``CombFilterBias``: ``sosfiltfilt`` already filters
+along a given axis independently of the others, so a 3-D 
+``(n_channels, n_times, n_epochs)``array needs no loop.

--- a/docs/changes/devel/74.misc.rst
+++ b/docs/changes/devel/74.misc.rst
@@ -1,7 +1,7 @@
 Added ``mne_denoise._filtering.design_butter_sos``, replacing independently
 hand-rolled Butterworth SOS design in ICanClean, the DSS covariance segmenter,
 ZapLine's cleanline notch fallback, and DSS's ``BandpassBias``. Also removed
-the manual per-epoch ``sosfiltfilt`` loops in ``BandpassBias``, 
+the manual per-epoch ``sosfiltfilt`` loops in ``BandpassBias``,
 ``PeakFilterBias``, and ``CombFilterBias``: ``sosfiltfilt`` already filters
-along a given axis independently of the others, so a 3-D 
-``(n_channels, n_times, n_epochs)``array needs no loop.
+along a given axis independently of the others, so a 3-D
+``(n_channels, n_times, n_epochs)`` array needs no loop.

--- a/mne_denoise/_filtering.py
+++ b/mne_denoise/_filtering.py
@@ -1,0 +1,38 @@
+"""Shared Butterworth SOS filter design for internal package use.
+
+This module centralizes the zero-phase Butterworth filter step used by
+several denoisers so callers pass Hz-domain edges directly via
+``fs=sfreq`` instead of each independently pre-dividing by Nyquist.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.signal import butter, sosfiltfilt
+
+
+def design_butter_sos(
+    order: int,
+    freqs: float | tuple[float, float],
+    btype: str,
+    sfreq: float,
+) -> np.ndarray:
+    """Design a Butterworth filter as second-order sections.
+
+    ``freqs`` is in Hz; normalization by Nyquist is handled internally via
+    ``fs=sfreq`` rather than by the caller.
+    """
+    return butter(order, freqs, btype=btype, fs=sfreq, output="sos")
+
+
+def _filter_channels(
+    data: np.ndarray,
+    filter_spec: tuple[str, float | tuple[float, float]] | None,
+    sfreq: float,
+) -> np.ndarray:
+    """Filter along the last axis with a zero-phase 4th-order Butterworth."""
+    if filter_spec is None:
+        return data
+    btype, freqs = filter_spec
+    sos = design_butter_sos(4, freqs, btype, sfreq)
+    return sosfiltfilt(sos, data, axis=-1)

--- a/mne_denoise/dss/denoisers/periodic.py
+++ b/mne_denoise/dss/denoisers/periodic.py
@@ -109,17 +109,11 @@ class PeakFilterBias(LinearDenoiser):
         biased : ndarray, same shape as input
             Peak-filtered data.
         """
-        if data.ndim == 3:
-            n_channels, n_times, n_epochs = data.shape
-            biased = np.zeros_like(data)
-            for ep in range(n_epochs):
-                biased[:, :, ep] = signal.sosfiltfilt(self._sos, data[:, :, ep], axis=1)
-        elif data.ndim == 2:
-            biased = signal.sosfiltfilt(self._sos, data, axis=1)
-        else:
+        if data.ndim not in (2, 3):
             raise ValueError(f"Data must be 2D or 3D, got {data.ndim}D")
-
-        return biased
+        # sosfiltfilt filters along `axis` independently of the other axes,
+        # so a 3D (n_channels, n_times, n_epochs) array needs no per-epoch loop.
+        return signal.sosfiltfilt(self._sos, data, axis=1)
 
 
 class CombFilterBias(LinearDenoiser):
@@ -252,20 +246,14 @@ class CombFilterBias(LinearDenoiser):
         """
         if len(self._peak_filters) == 0:
             raise ValueError("No valid harmonics within Nyquist frequency")
+        if data.ndim not in (2, 3):
+            raise ValueError(f"Data must be 2D or 3D, got {data.ndim}D")
 
+        # sosfiltfilt filters along `axis` independently of the other axes,
+        # so a 3D (n_channels, n_times, n_epochs) array needs no per-epoch loop.
         biased = np.zeros_like(data)
-
         for sos, weight in self._peak_filters:
-            if data.ndim == 3:
-                n_channels, n_times, n_epochs = data.shape
-                for ep in range(n_epochs):
-                    biased[:, :, ep] += weight * signal.sosfiltfilt(
-                        sos, data[:, :, ep], axis=1
-                    )
-            elif data.ndim == 2:
-                biased += weight * signal.sosfiltfilt(sos, data, axis=1)
-            else:
-                raise ValueError(f"Data must be 2D or 3D, got {data.ndim}D")
+            biased += weight * signal.sosfiltfilt(sos, data, axis=1)
 
         return biased
 

--- a/mne_denoise/dss/denoisers/spectral.py
+++ b/mne_denoise/dss/denoisers/spectral.py
@@ -18,6 +18,7 @@ import numpy as np
 from scipy import signal
 from scipy.fft import fft, ifft
 
+from ..._filtering import design_butter_sos
 from .base import LinearDenoiser
 
 
@@ -85,12 +86,7 @@ class BandpassBias(LinearDenoiser):
 
         if self.method == "butter":
             # Use second-order sections for stability
-            self._sos = signal.butter(
-                self.order,
-                [low / nyq, high / nyq],
-                btype="band",
-                output="sos",
-            )
+            self._sos = design_butter_sos(self.order, [low, high], "band", self.sfreq)
         else:
             raise ValueError(f"Unknown filter method: {self.method}")
 
@@ -107,19 +103,11 @@ class BandpassBias(LinearDenoiser):
         biased : ndarray, same shape as input
             Bandpass filtered data.
         """
-        # Handle 3D epoched data
-        if data.ndim == 3:
-            n_channels, n_times, n_epochs = data.shape
-            # Process each epoch separately to avoid edge effects between epochs
-            biased = np.zeros_like(data)
-            for ep in range(n_epochs):
-                biased[:, :, ep] = signal.sosfiltfilt(self._sos, data[:, :, ep], axis=1)
-        elif data.ndim == 2:
-            biased = signal.sosfiltfilt(self._sos, data, axis=1)
-        else:
+        if data.ndim not in (2, 3):
             raise ValueError(f"Data must be 2D or 3D, got {data.ndim}D")
-
-        return biased
+        # sosfiltfilt filters along `axis` independently of the other axes,
+        # so a 3D (n_channels, n_times, n_epochs) array needs no per-epoch loop.
+        return signal.sosfiltfilt(self._sos, data, axis=1)
 
 
 class LineNoiseBias(LinearDenoiser):

--- a/mne_denoise/dss/utils/segmentation.py
+++ b/mne_denoise/dss/utils/segmentation.py
@@ -26,6 +26,7 @@ from scipy import signal
 from scipy.signal import find_peaks
 
 from ..._covariance import compute_covariance
+from ..._filtering import design_butter_sos
 
 # ---------------------------------------------------------------------------
 # Covariance-based segmenter (generalised from ZapLine-plus)
@@ -99,9 +100,7 @@ class CovarianceSegmenter:
         # Optional bandpass filter to focus analysis
         if self.bandpass is not None:
             f_low, f_high = self.bandpass
-            sos = signal.butter(
-                4, [f_low, f_high], btype="bandpass", fs=self.sfreq, output="sos"
-            )
+            sos = design_butter_sos(4, [f_low, f_high], "bandpass", self.sfreq)
             data_filt = signal.sosfiltfilt(sos, data, axis=1)
         else:
             data_filt = data

--- a/mne_denoise/icanclean/core.py
+++ b/mne_denoise/icanclean/core.py
@@ -507,6 +507,22 @@ class ICanClean(BaseEstimator, TransformerMixin):
         on the broader window but only the inner ``segment_len`` portion
         is cleaned. This is only valid for ``'sliding'`` and ``'hybrid'``
         modes and must be greater than or equal to ``segment_len``.
+    filter_ref : tuple | None, default=None
+        Filter applied to the reference block before CCA, as
+        ``(kind, freqs)``: ``('notch', (lo, hi))`` band-stops lo-hi Hz,
+        ``('bp', (lo, hi))`` band-passes, ``('hp', f)`` and ``('lp', f)``
+        high- and low-pass. Zero-phase 4th-order Butterworth. Note that
+        ``'notch'`` here is a wide band-stop used to shape what the
+        reference retains, not a narrowband line-noise filter.
+    pseudo_ref : bool, default=False
+        Derive the reference block from the primary channels instead of
+        using physical reference sensors. A copy of the primary channels is
+        filtered with ``filter_ref`` and appended as the reference, so CCA
+        correlates the EEG against a version of itself that keeps only
+        out-of-band content -- typically drift below the brain band and
+        EMG/line above it. Requires ``filter_ref``; makes ``ref_channels``
+        optional. This is the pseudo-reference method of Downey & Ferris
+        (2023), for recordings with no dual-layer noise electrodes.
     global_threshold : float | 'auto' | None, default=None
         Threshold for the explicit global pass in ``mode='hybrid'``.
     global_clean_with : {'X', 'Y', 'both'} | None, default=None
@@ -622,13 +638,25 @@ class ICanClean(BaseEstimator, TransformerMixin):
         reref_primary: bool | str = False,
         reref_ref: bool | str = False,
         stats_segment_len: float | None = None,
+        filter_ref: tuple | None = None,
+        pseudo_ref: bool = False,
         global_threshold: float | str | None = None,
         global_clean_with: str | None = None,
         global_max_reject_fraction: float | None = None,
         verbose: bool | str | int | None = None,
     ):
-        if ref_channels is None:
+        # In pseudo-reference mode the reference block is derived from the
+        # primary channels themselves, so there are no reference channels for
+        # the caller to name.
+        if ref_channels is None and not pseudo_ref:
             raise ValueError("ref_channels must be provided explicitly")
+        _validate_filter_ref(filter_ref)
+        if pseudo_ref and filter_ref is None:
+            raise ValueError(
+                "pseudo_ref=True requires filter_ref. Without a filter the "
+                "reference block is identical to the primary block, every "
+                "canonical correlation is 1.0, and the whole signal is removed."
+            )
         _validate_icanclean_config(
             mode=mode,
             clean_with=clean_with,
@@ -656,6 +684,8 @@ class ICanClean(BaseEstimator, TransformerMixin):
         self.reref_primary = reref_primary
         self.reref_ref = reref_ref
         self.stats_segment_len = stats_segment_len
+        self.filter_ref = filter_ref
+        self.pseudo_ref = pseudo_ref
         self.global_threshold = global_threshold
         self.global_clean_with = global_clean_with
         self.global_max_reject_fraction = global_max_reject_fraction
@@ -713,15 +743,75 @@ class ICanClean(BaseEstimator, TransformerMixin):
         sfreq = sfreq_data if sfreq_data is not None else self.sfreq
         channel_data = data[0] if mne_type == "epochs" else data
         primary_idx, ref_idx = self._resolve_channels(channel_data, orig_inst)
+        data, ref_idx, n_orig = self._build_reference_block(
+            data, sfreq, primary_idx, ref_idx
+        )
 
         if mne_type == "epochs":
             cleaned = self._transform_epochs(data, sfreq, primary_idx, ref_idx)
         else:
             cleaned = self._clean_continuous(data, sfreq, primary_idx, ref_idx)
 
+        if n_orig is not None:
+            # Drop the pseudo-reference rows appended above so the output has
+            # the same channel set as the input.
+            cleaned = cleaned[..., :n_orig, :]
+
         return reconstruct_mne_object(
             cleaned, orig_inst, mne_type, picks=picks, verbose=False
         )
+
+    def _build_reference_block(
+        self,
+        data: np.ndarray,
+        sfreq: float,
+        primary_idx: np.ndarray,
+        ref_idx: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray, int | None]:
+        """Construct the reference block CCA will run against.
+
+        Three cases:
+
+        - ``pseudo_ref=True``: no physical reference exists. A copy of the
+          primary channels is filtered with ``filter_ref`` and appended as the
+          reference block, so CCA correlates the EEG against a version of
+          itself that retains only out-of-band content. This is the
+          pseudo-reference method of Downey & Ferris (2023).
+        - ``filter_ref`` set without ``pseudo_ref``: the real reference
+          channels are filtered in place, on a copy.
+        - neither: the data is returned untouched.
+
+        Returns
+        -------
+        data, ref_idx, n_orig
+            ``n_orig`` is the original channel count when rows were appended
+            and must be stripped afterwards, else ``None``.
+        """
+        if not self.pseudo_ref and self.filter_ref is None:
+            return data, ref_idx, None
+
+        # Continuous data is (n_channels, n_times); epochs are
+        # (n_epochs, n_channels, n_times). Filtering always runs on the last
+        # axis, but the channel axis moves.
+        ch_axis = data.ndim - 2
+        n_orig = data.shape[ch_axis]
+
+        if self.pseudo_ref:
+            pseudo = _filter_channels(
+                np.take(data, primary_idx, axis=ch_axis).copy(), self.filter_ref, sfreq
+            )
+            data = np.concatenate([data, pseudo], axis=ch_axis)
+            return data, np.arange(n_orig, data.shape[ch_axis], dtype=int), n_orig
+
+        data = data.copy()
+        filtered = _filter_channels(
+            np.take(data, ref_idx, axis=ch_axis), self.filter_ref, sfreq
+        )
+        if ch_axis == 0:
+            data[ref_idx, :] = filtered
+        else:
+            data[:, ref_idx, :] = filtered
+        return data, ref_idx, None
 
     def fit_transform(self, X: Any, y=None, **fit_params) -> Any:
         """Fit and apply ICanClean in one step.
@@ -908,6 +998,24 @@ class ICanClean(BaseEstimator, TransformerMixin):
         ch_names = None
         if mne is not None and orig_inst is not None and hasattr(orig_inst, "ch_names"):
             ch_names = list(orig_inst.ch_names)
+
+        if self.ref_channels is None:
+            # Only reachable with pseudo_ref=True, which the constructor
+            # enforces. The reference block does not exist yet; it is built
+            # from the primary channels in _build_reference_block.
+            if self.primary_channels is not None:
+                if ch_names is not None and isinstance(self.primary_channels[0], str):
+                    primary_idx = np.array(
+                        [ch_names.index(ch) for ch in self.primary_channels], dtype=int
+                    )
+                else:
+                    primary_idx = np.asarray(self.primary_channels, dtype=int)
+            else:
+                primary_idx = np.arange(n_channels, dtype=int)
+            if ch_names is not None:
+                self.primary_channels_ = [ch_names[i] for i in primary_idx]
+                self.ref_channels_ = None
+            return primary_idx, np.array([], dtype=int)
 
         if ch_names is not None and isinstance(self.ref_channels[0], str):
             ref_idx = np.array(
@@ -1154,6 +1262,72 @@ def _validate_icanclean_config(
             "global_max_reject_fraction are only supported when "
             "mode='hybrid'"
         )
+
+
+#: Filter kinds accepted by ``filter_ref``, mapped to their scipy btype.
+_FILTER_REF_BTYPES = {
+    "notch": "bandstop",
+    "hp": "highpass",
+    "lp": "lowpass",
+    "bp": "bandpass",
+}
+
+
+def _validate_filter_ref(filter_ref: tuple | None) -> None:
+    """Check a ``filter_ref`` spec before any data is touched."""
+    if filter_ref is None:
+        return
+    if not isinstance(filter_ref, (tuple, list)) or len(filter_ref) != 2:
+        raise ValueError(
+            f"filter_ref must be a (kind, freqs) pair, got {filter_ref!r}"
+        )
+    kind, freqs = filter_ref
+    if kind not in _FILTER_REF_BTYPES:
+        raise ValueError(
+            f"filter_ref kind must be one of {sorted(_FILTER_REF_BTYPES)}, got {kind!r}"
+        )
+    if kind in ("notch", "bp"):
+        if not isinstance(freqs, (tuple, list)) or len(freqs) != 2:
+            raise ValueError(f"filter_ref {kind!r} needs a (low, high) pair")
+        if not freqs[0] < freqs[1]:
+            raise ValueError(f"filter_ref {kind!r} needs low < high, got {freqs!r}")
+    elif not np.isscalar(freqs):
+        raise ValueError(f"filter_ref {kind!r} needs a single frequency")
+
+
+def _filter_channels(
+    data: np.ndarray,
+    filter_spec: tuple | None,
+    sfreq: float,
+) -> np.ndarray:
+    """Filter along the last axis with a zero-phase 4th-order Butterworth.
+
+    ``('notch', (lo, hi))`` is a **band-stop**: it removes lo-hi Hz and keeps
+    everything outside. That is the operation the pseudo-reference method
+    needs -- suppressing the brain band leaves drift below it and EMG/line
+    above it, which is what CCA should lock onto. This matches MATLAB
+    ``filtYtype='Notch'``; it is not a narrowband line-noise notch.
+    """
+    if filter_spec is None:
+        return data
+    from scipy.signal import butter, sosfiltfilt
+
+    kind, freqs = filter_spec
+    nyquist = sfreq / 2.0
+    wn = list(freqs) if kind in ("notch", "bp") else [freqs]
+    if max(wn) >= nyquist:
+        raise ValueError(
+            f"filter_ref {filter_spec!r} exceeds Nyquist ({nyquist} Hz) for "
+            f"sfreq={sfreq}"
+        )
+    sos = butter(
+        4,
+        wn if len(wn) == 2 else wn[0],
+        btype=_FILTER_REF_BTYPES[kind],
+        fs=sfreq,
+        output="sos",
+    )
+    return sosfiltfilt(sos, data, axis=-1)
 
 
 def _select_basis(

--- a/mne_denoise/icanclean/core.py
+++ b/mne_denoise/icanclean/core.py
@@ -60,6 +60,7 @@ from scipy import linalg as la
 from sklearn.base import BaseEstimator, TransformerMixin
 
 from .._cca import canonical_correlation
+from .._filtering import _filter_channels
 from .._logging import set_log_level_from_verbose
 from ..utils import extract_data_from_mne, reconstruct_mne_object
 
@@ -509,20 +510,21 @@ class ICanClean(BaseEstimator, TransformerMixin):
         modes and must be greater than or equal to ``segment_len``.
     filter_ref : tuple | None, default=None
         Filter applied to the reference block before CCA, as
-        ``(kind, freqs)``: ``('notch', (lo, hi))`` band-stops lo-hi Hz,
-        ``('bp', (lo, hi))`` band-passes, ``('hp', f)`` and ``('lp', f)``
-        high- and low-pass. Zero-phase 4th-order Butterworth. Note that
-        ``'notch'`` here is a wide band-stop used to shape what the
-        reference retains, not a narrowband line-noise filter.
+        ``(btype, freqs)`` using scipy's own filter-kind names:
+        ``('bandstop', (lo, hi))``, ``('bandpass', (lo, hi))``,
+        ``('highpass', f)``, ``('lowpass', f)``. Zero-phase 4th-order
+        Butterworth. ``'bandstop'`` here is a wide band-stop used to shape
+        what the reference retains (ie. notch) a narrowband line-noise filter.
     pseudo_ref : bool, default=False
         Derive the reference block from the primary channels instead of
         using physical reference sensors. A copy of the primary channels is
         filtered with ``filter_ref`` and appended as the reference, so CCA
         correlates the EEG against a version of itself that keeps only
         out-of-band content -- typically drift below the brain band and
-        EMG/line above it. Requires ``filter_ref``; makes ``ref_channels``
-        optional. This is the pseudo-reference method of Downey & Ferris
-        (2023), for recordings with no dual-layer noise electrodes.
+        EMG/line above it. Requires ``filter_ref``; mutually exclusive with
+        ``ref_channels``, which must be left as ``None``. This is the
+        pseudo-reference method of Downey & Ferris (2023) [2]_, for
+        recordings with no dual-layer noise electrodes.
     global_threshold : float | 'auto' | None, default=None
         Threshold for the explicit global pass in ``mode='hybrid'``.
     global_clean_with : {'X', 'Y', 'both'} | None, default=None
@@ -650,7 +652,13 @@ class ICanClean(BaseEstimator, TransformerMixin):
         # the caller to name.
         if ref_channels is None and not pseudo_ref:
             raise ValueError("ref_channels must be provided explicitly")
-        _validate_filter_ref(filter_ref)
+        if pseudo_ref and ref_channels is not None:
+            raise ValueError(
+                "pseudo_ref=True builds its own reference block from the "
+                "primary channels; ref_channels is not used in this mode "
+                "and would be silently ignored, so it must be left as None."
+            )
+        _validate_filter_ref(filter_ref, sfreq)
         if pseudo_ref and filter_ref is None:
             raise ValueError(
                 "pseudo_ref=True requires filter_ref. Without a filter the "
@@ -1264,68 +1272,42 @@ def _validate_icanclean_config(
         )
 
 
-#: Filter kinds accepted by ``filter_ref``, mapped to their scipy btype.
-_FILTER_REF_BTYPES = {
-    "notch": "bandstop",
-    "hp": "highpass",
-    "lp": "lowpass",
-    "bp": "bandpass",
-}
+#: btypes accepted by ``filter_ref`` -- scipy's own names, not a shorthand.
+_FILTER_REF_BTYPES = ("bandpass", "bandstop", "highpass", "lowpass")
 
 
-def _validate_filter_ref(filter_ref: tuple | None) -> None:
-    """Check a ``filter_ref`` spec before any data is touched."""
+def _validate_filter_ref(filter_ref: tuple | None, sfreq: float) -> None:
+    """Check a ``filter_ref`` spec against ``sfreq`` before any data is touched."""
     if filter_ref is None:
         return
     if not isinstance(filter_ref, (tuple, list)) or len(filter_ref) != 2:
-        raise ValueError(f"filter_ref must be a (kind, freqs) pair, got {filter_ref!r}")
+        raise ValueError(
+            f"filter_ref must be a (btype, freqs) pair, got {filter_ref!r}"
+        )
     kind, freqs = filter_ref
     if kind not in _FILTER_REF_BTYPES:
         raise ValueError(
-            f"filter_ref kind must be one of {sorted(_FILTER_REF_BTYPES)}, got {kind!r}"
+            f"filter_ref btype must be one of {sorted(_FILTER_REF_BTYPES)}, got {kind!r}"
         )
-    if kind in ("notch", "bp"):
+    if kind in ("bandstop", "bandpass"):
         if not isinstance(freqs, (tuple, list)) or len(freqs) != 2:
             raise ValueError(f"filter_ref {kind!r} needs a (low, high) pair")
-        if not freqs[0] < freqs[1]:
-            raise ValueError(f"filter_ref {kind!r} needs low < high, got {freqs!r}")
-    elif not np.isscalar(freqs):
-        raise ValueError(f"filter_ref {kind!r} needs a single frequency")
-
-
-def _filter_channels(
-    data: np.ndarray,
-    filter_spec: tuple | None,
-    sfreq: float,
-) -> np.ndarray:
-    """Filter along the last axis with a zero-phase 4th-order Butterworth.
-
-    ``('notch', (lo, hi))`` is a **band-stop**: it removes lo-hi Hz and keeps
-    everything outside. That is the operation the pseudo-reference method
-    needs -- suppressing the brain band leaves drift below it and EMG/line
-    above it, which is what CCA should lock onto. This matches MATLAB
-    ``filtYtype='Notch'``; it is not a narrowband line-noise notch.
-    """
-    if filter_spec is None:
-        return data
-    from scipy.signal import butter, sosfiltfilt
-
-    kind, freqs = filter_spec
+        if not 0 < freqs[0] < freqs[1]:
+            raise ValueError(f"filter_ref {kind!r} needs 0 < low < high, got {freqs!r}")
+        max_freq = freqs[1]
+    else:
+        if not np.isscalar(freqs):
+            raise ValueError(f"filter_ref {kind!r} needs a single frequency")
+        if freqs <= 0:
+            raise ValueError(
+                f"filter_ref {kind!r} needs a positive frequency, got {freqs!r}"
+            )
+        max_freq = freqs
     nyquist = sfreq / 2.0
-    wn = list(freqs) if kind in ("notch", "bp") else [freqs]
-    if max(wn) >= nyquist:
+    if max_freq >= nyquist:
         raise ValueError(
-            f"filter_ref {filter_spec!r} exceeds Nyquist ({nyquist} Hz) for "
-            f"sfreq={sfreq}"
+            f"filter_ref {filter_ref!r} exceeds Nyquist ({nyquist} Hz) for sfreq={sfreq}"
         )
-    sos = butter(
-        4,
-        wn if len(wn) == 2 else wn[0],
-        btype=_FILTER_REF_BTYPES[kind],
-        fs=sfreq,
-        output="sos",
-    )
-    return sosfiltfilt(sos, data, axis=-1)
 
 
 def _select_basis(

--- a/mne_denoise/icanclean/core.py
+++ b/mne_denoise/icanclean/core.py
@@ -1278,9 +1278,7 @@ def _validate_filter_ref(filter_ref: tuple | None) -> None:
     if filter_ref is None:
         return
     if not isinstance(filter_ref, (tuple, list)) or len(filter_ref) != 2:
-        raise ValueError(
-            f"filter_ref must be a (kind, freqs) pair, got {filter_ref!r}"
-        )
+        raise ValueError(f"filter_ref must be a (kind, freqs) pair, got {filter_ref!r}")
     kind, freqs = filter_ref
     if kind not in _FILTER_REF_BTYPES:
         raise ValueError(

--- a/mne_denoise/zapline/adaptive.py
+++ b/mne_denoise/zapline/adaptive.py
@@ -45,6 +45,8 @@ import numpy as np
 from scipy import signal
 from scipy.signal import find_peaks, welch
 
+from .._filtering import design_butter_sos
+
 logger = logging.getLogger(__name__)
 
 
@@ -89,18 +91,14 @@ def apply_cleanline_notch(
     """
     # Design notch filter
     nyquist = sfreq / 2
-    low = (freq - bandwidth / 2) / nyquist
-    high = (freq + bandwidth / 2) / nyquist
-
-    # Ensure within valid range
-    low = max(0.001, min(low, 0.999))
-    high = max(0.001, min(high, 0.999))
+    low = max(0.001 * nyquist, freq - bandwidth / 2)
+    high = min(0.999 * nyquist, freq + bandwidth / 2)
 
     if low >= high:
         return data  # Cannot filter, return unchanged
 
     # Use bandstop (notch) filter
-    sos = signal.butter(order, [low, high], btype="bandstop", output="sos")
+    sos = design_butter_sos(order, [low, high], "bandstop", sfreq)
     filtered = signal.sosfiltfilt(sos, data, axis=1)
 
     return filtered

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1,0 +1,98 @@
+"""Tests for the shared filtering helpers (mne_denoise._filtering)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.signal import butter, sosfiltfilt
+
+from mne_denoise._filtering import _filter_channels, design_butter_sos
+
+SFREQ = 250.0
+
+
+def _tone(freq: float, sfreq: float = SFREQ, n: int = 5000) -> np.ndarray:
+    t = np.arange(n) / sfreq
+    return np.sin(2 * np.pi * freq * t)
+
+
+def _kept_ratio(
+    filtered: np.ndarray, original: np.ndarray, sfreq: float = SFREQ
+) -> float:
+    """Ratio of filtered to original amplitude, past the filtfilt edge transient."""
+    edge = int(sfreq)
+    return np.std(filtered[edge:-edge]) / np.std(original[edge:-edge])
+
+
+@pytest.mark.parametrize(
+    "order, freqs, btype",
+    [
+        (4, 30.0, "lowpass"),
+        (2, 30.0, "highpass"),
+        (4, (8.0, 12.0), "bandpass"),
+        (4, (8.0, 12.0), "bandstop"),
+    ],
+)
+def test_design_butter_sos_matches_scipy_butter(order, freqs, btype):
+    """design_butter_sos is a thin fs= wrapper -- must match butter() exactly."""
+    got = design_butter_sos(order, freqs, btype, SFREQ)
+    expected = butter(order, freqs, btype=btype, fs=SFREQ, output="sos")
+    assert np.array_equal(got, expected)
+
+
+def test_design_butter_sos_lowpass_passes_low_blocks_high():
+    sos = design_butter_sos(4, 30.0, "lowpass", SFREQ)
+    low, high = _tone(5.0), _tone(80.0)
+    assert _kept_ratio(sosfiltfilt(sos, low), low) > 0.9
+    assert _kept_ratio(sosfiltfilt(sos, high), high) < 0.05
+
+
+def test_design_butter_sos_highpass_blocks_low_passes_high():
+    sos = design_butter_sos(4, 30.0, "highpass", SFREQ)
+    low, high = _tone(5.0), _tone(80.0)
+    assert _kept_ratio(sosfiltfilt(sos, low), low) < 0.05
+    assert _kept_ratio(sosfiltfilt(sos, high), high) > 0.9
+
+
+def test_design_butter_sos_bandpass_keeps_band_blocks_outside():
+    sos = design_butter_sos(4, (8.0, 12.0), "bandpass", SFREQ)
+    inside, outside = _tone(10.0), _tone(50.0)
+    assert _kept_ratio(sosfiltfilt(sos, inside), inside) > 0.9
+    assert _kept_ratio(sosfiltfilt(sos, outside), outside) < 0.05
+
+
+def test_design_butter_sos_bandstop_blocks_band_keeps_outside():
+    sos = design_butter_sos(4, (8.0, 12.0), "bandstop", SFREQ)
+    inside, outside = _tone(10.0), _tone(50.0)
+    assert _kept_ratio(sosfiltfilt(sos, inside), inside) < 0.05
+    assert _kept_ratio(sosfiltfilt(sos, outside), outside) > 0.9
+
+
+@pytest.mark.parametrize("sfreq", [100.0, 250.0, 1000.0])
+def test_design_butter_sos_freqs_are_hz_not_prenormalized(sfreq):
+    """``freqs`` is Hz, normalized internally via ``fs`` -- not pre-divided by
+    Nyquist by the caller. Design a fixed fraction of Nyquist at several
+    sampling rates and confirm the passband tracks ``sfreq`` rather than
+    being fixed to whatever rate the caller's arithmetic assumed.
+    """
+    target = sfreq / 10.0
+    sos = design_butter_sos(4, target, "lowpass", sfreq)
+    below, above = _tone(target * 0.3, sfreq=sfreq), _tone(target * 3.0, sfreq=sfreq)
+    assert _kept_ratio(sosfiltfilt(sos, below), below, sfreq=sfreq) > 0.9
+    assert _kept_ratio(sosfiltfilt(sos, above), above, sfreq=sfreq) < 0.05
+
+
+def test_filter_channels_none_spec_is_a_no_op():
+    """A ``None`` filter_spec must return the input untouched."""
+    data = np.random.default_rng(0).standard_normal((3, 100))
+    assert _filter_channels(data, None, SFREQ) is data
+
+
+def test_filter_channels_bandstop_removes_only_the_band():
+    """('bandstop', (lo, hi)) must keep outside the band, drop inside it."""
+    inside, outside = _tone(20.0), _tone(2.0)  # 20 Hz inside 5-45, 2 Hz below it
+    data = np.vstack([inside, outside])
+
+    out = _filter_channels(data, ("bandstop", (5.0, 45.0)), SFREQ)
+    assert _kept_ratio(out[0], inside) < 0.05
+    assert _kept_ratio(out[1], outside) > 0.90

--- a/tests/test_icanclean.py
+++ b/tests/test_icanclean.py
@@ -526,7 +526,12 @@ def test_icanclean_validation_removed_workflows():
 
 def test_filter_ref_validation():
     """A malformed filter_ref spec is rejected before any data is touched."""
-    for bad in [("bogus", 10.0), ("notch", 10.0), ("notch", (45.0, 5.0)), ("hp", (1, 2))]:
+    for bad in [
+        ("bogus", 10.0),
+        ("notch", 10.0),
+        ("notch", (45.0, 5.0)),
+        ("hp", (1, 2)),
+    ]:
         with pytest.raises(ValueError):
             ICanClean(sfreq=250.0, ref_channels=[0], filter_ref=bad)
 

--- a/tests/test_icanclean.py
+++ b/tests/test_icanclean.py
@@ -528,9 +528,9 @@ def test_filter_ref_validation():
     """A malformed filter_ref spec is rejected before any data is touched."""
     for bad in [
         ("bogus", 10.0),
-        ("notch", 10.0),
-        ("notch", (45.0, 5.0)),
-        ("hp", (1, 2)),
+        ("bandstop", 10.0),
+        ("bandstop", (45.0, 5.0)),
+        ("highpass", (1, 2)),
     ]:
         with pytest.raises(ValueError):
             ICanClean(sfreq=250.0, ref_channels=[0], filter_ref=bad)
@@ -548,29 +548,52 @@ def test_pseudo_ref_needs_no_ref_channels():
         sfreq=250.0,
         primary_channels=[0, 1],
         pseudo_ref=True,
-        filter_ref=("notch", (5.0, 45.0)),
+        filter_ref=("bandstop", (5.0, 45.0)),
     )
     assert icc.ref_channels is None
     with pytest.raises(ValueError, match="ref_channels must be provided"):
         ICanClean(sfreq=250.0, primary_channels=[0, 1])
 
 
-def test_filter_channels_bandstop_removes_only_the_band():
-    """('notch', (lo, hi)) must be a band-stop: keep outside, drop inside."""
-    from mne_denoise.icanclean.core import _filter_channels
+def test_pseudo_ref_rejects_ref_channels():
+    """pseudo_ref builds its own reference; a real ref_channels would be
 
-    sfreq, n = 250.0, 5000
-    t = np.arange(n) / sfreq
-    inside = np.sin(2 * np.pi * 20.0 * t)  # 20 Hz, inside 5-45
-    outside = np.sin(2 * np.pi * 2.0 * t)  # 2 Hz, below the band
-    data = np.vstack([inside, outside])
+    silently ignored (the CCA reference is always rebuilt from the primary
+    channels once pseudo_ref=True), so combining the two must raise instead.
+    """
+    with pytest.raises(ValueError, match="ref_channels is not used"):
+        ICanClean(
+            sfreq=250.0,
+            ref_channels=[3],
+            pseudo_ref=True,
+            filter_ref=("bandstop", (5.0, 45.0)),
+        )
 
-    out = _filter_channels(data, ("notch", (5.0, 45.0)), sfreq)
-    edge = int(sfreq)  # ignore filter edge transients
-    kept_in = np.std(out[0, edge:-edge]) / np.std(inside[edge:-edge])
-    kept_out = np.std(out[1, edge:-edge]) / np.std(outside[edge:-edge])
-    assert kept_in < 0.05, f"20 Hz should be suppressed, kept {kept_in:.3f}"
-    assert kept_out > 0.90, f"2 Hz should survive, kept {kept_out:.3f}"
+
+def test_filter_ref_rejects_non_positive_frequencies():
+    """A zero or negative band edge fails scipy's own Wn check with a
+
+    confusing message; catch it at construction like the Nyquist check does.
+    """
+    for bad in [
+        ("highpass", 0.0),
+        ("lowpass", -1.0),
+        ("bandstop", (0.0, 45.0)),
+        ("bandpass", (-5.0, 10.0)),
+    ]:
+        with pytest.raises(ValueError):
+            ICanClean(sfreq=250.0, ref_channels=[0], filter_ref=bad)
+
+
+def test_filter_ref_rejects_band_edge_at_or_above_nyquist():
+    """A band edge at or above Nyquist must raise at construction, not fail
+
+    inside scipy the first time data is transformed.
+    """
+    with pytest.raises(ValueError, match="Nyquist"):
+        ICanClean(sfreq=250.0, ref_channels=[0], filter_ref=("lowpass", 125.0))
+    with pytest.raises(ValueError, match="Nyquist"):
+        ICanClean(sfreq=250.0, ref_channels=[0], filter_ref=("bandstop", (5.0, 200.0)))
 
 
 def test_pseudo_ref_preserves_channel_count_and_shape(synthetic_dual_layer):
@@ -580,7 +603,7 @@ def test_pseudo_ref_preserves_channel_count_and_shape(synthetic_dual_layer):
         sfreq=sfreq,
         primary_channels=primary_idx,
         pseudo_ref=True,
-        filter_ref=("notch", (5.0, 45.0)),
+        filter_ref=("bandstop", (5.0, 45.0)),
         segment_len=1.0,
         threshold=0.9,
         verbose=False,
@@ -606,7 +629,7 @@ def test_pseudo_ref_removes_out_of_band_artifact(synthetic_dual_layer):
         sfreq=sfreq,
         primary_channels=list(range(len(primary_idx))),
         pseudo_ref=True,
-        filter_ref=("notch", (5.0, 45.0)),
+        filter_ref=("bandstop", (5.0, 45.0)),
         segment_len=2.0,
         threshold=0.5,
         verbose=False,

--- a/tests/test_icanclean.py
+++ b/tests/test_icanclean.py
@@ -517,14 +517,101 @@ def test_icanclean_validation_removed_workflows():
         ICanClean(sfreq=250.0, ref_channels=[0], primary_prefix="EEG")
     with pytest.raises(TypeError):
         ICanClean(sfreq=250.0, ref_channels=[0], exclude_pattern="EXG")
-    with pytest.raises(TypeError):
-        ICanClean(sfreq=250.0, ref_channels=[0], pseudo_ref=True)
-    with pytest.raises(TypeError):
-        ICanClean(
-            sfreq=250.0,
-            ref_channels=[0],
-            filter_ref=("notch", (49.0, 51.0)),
-        )
+
+
+# ---------------------------------------------------------------------------
+# Pseudo-reference mode (Downey & Ferris 2023, Sensors 23(19):8214)
+# ---------------------------------------------------------------------------
+
+
+def test_filter_ref_validation():
+    """A malformed filter_ref spec is rejected before any data is touched."""
+    for bad in [("bogus", 10.0), ("notch", 10.0), ("notch", (45.0, 5.0)), ("hp", (1, 2))]:
+        with pytest.raises(ValueError):
+            ICanClean(sfreq=250.0, ref_channels=[0], filter_ref=bad)
+
+
+def test_pseudo_ref_requires_filter_ref():
+    """Without a filter the reference equals the primary block: r=1 everywhere."""
+    with pytest.raises(ValueError, match="requires filter_ref"):
+        ICanClean(sfreq=250.0, primary_channels=[0, 1], pseudo_ref=True)
+
+
+def test_pseudo_ref_needs_no_ref_channels():
+    """pseudo_ref supplies its own reference, so ref_channels is optional."""
+    icc = ICanClean(
+        sfreq=250.0,
+        primary_channels=[0, 1],
+        pseudo_ref=True,
+        filter_ref=("notch", (5.0, 45.0)),
+    )
+    assert icc.ref_channels is None
+    with pytest.raises(ValueError, match="ref_channels must be provided"):
+        ICanClean(sfreq=250.0, primary_channels=[0, 1])
+
+
+def test_filter_channels_bandstop_removes_only_the_band():
+    """('notch', (lo, hi)) must be a band-stop: keep outside, drop inside."""
+    from mne_denoise.icanclean.core import _filter_channels
+
+    sfreq, n = 250.0, 5000
+    t = np.arange(n) / sfreq
+    inside = np.sin(2 * np.pi * 20.0 * t)  # 20 Hz, inside 5-45
+    outside = np.sin(2 * np.pi * 2.0 * t)  # 2 Hz, below the band
+    data = np.vstack([inside, outside])
+
+    out = _filter_channels(data, ("notch", (5.0, 45.0)), sfreq)
+    edge = int(sfreq)  # ignore filter edge transients
+    kept_in = np.std(out[0, edge:-edge]) / np.std(inside[edge:-edge])
+    kept_out = np.std(out[1, edge:-edge]) / np.std(outside[edge:-edge])
+    assert kept_in < 0.05, f"20 Hz should be suppressed, kept {kept_in:.3f}"
+    assert kept_out > 0.90, f"2 Hz should survive, kept {kept_out:.3f}"
+
+
+def test_pseudo_ref_preserves_channel_count_and_shape(synthetic_dual_layer):
+    """The appended pseudo-reference rows must not leak into the output."""
+    data, primary_idx, _ref_idx, sfreq, _truth = synthetic_dual_layer
+    icc = ICanClean(
+        sfreq=sfreq,
+        primary_channels=primary_idx,
+        pseudo_ref=True,
+        filter_ref=("notch", (5.0, 45.0)),
+        segment_len=1.0,
+        threshold=0.9,
+        verbose=False,
+    )
+    out = icc.fit_transform(data)
+    assert out.shape == data.shape
+
+
+def test_pseudo_ref_removes_out_of_band_artifact(synthetic_dual_layer):
+    """A strong sub-band drift shared across channels should be attenuated.
+
+    The pseudo-reference retains only content outside 5-45 Hz, so CCA can see
+    the drift but not the in-band signal.
+    """
+    data, primary_idx, _ref_idx, sfreq, truth = synthetic_dual_layer
+    primary = truth["brain"]
+    n_times = primary.shape[1]
+    t = np.arange(n_times) / sfreq
+    drift = 8.0 * np.sin(2 * np.pi * 0.7 * t)
+    contaminated = primary + drift[None, :]
+
+    icc = ICanClean(
+        sfreq=sfreq,
+        primary_channels=list(range(len(primary_idx))),
+        pseudo_ref=True,
+        filter_ref=("notch", (5.0, 45.0)),
+        segment_len=2.0,
+        threshold=0.5,
+        verbose=False,
+    )
+    cleaned = icc.fit_transform(contaminated)
+
+    edge = int(sfreq)
+    before = np.mean(np.abs(contaminated[:, edge:-edge] - primary[:, edge:-edge]))
+    after = np.mean(np.abs(cleaned[:, edge:-edge] - primary[:, edge:-edge]))
+    assert after < before, f"drift not attenuated: {before:.3f} -> {after:.3f}"
 
 
 def test_icanclean_max_reject_zero_preserves_data(synthetic_dual_layer):


### PR DESCRIPTION
Closes #68.

Restores the pseudo-reference method removed in `e38e8f5` without a changelog
entry. Reimplemented against the refactored `transform` path rather than
reverting the old patch, because the original had defects (below).

`pseudo_ref=True` derives the CCA reference block from the primary channels
themselves: a copy is filtered with `filter_ref` and appended as the reference,
so CCA correlates the EEG against a version of itself retaining only
out-of-band content. This is the method of Downey & Ferris 2023,
*Sensors* 23(19):8214, for recordings without a dual-layer cap.

### Defects in the original implementation, fixed here

- **Broke on Epochs.** The old code indexed the channel axis as axis 0
  unconditionally — correct for continuous `(n_channels, n_times)`, wrong for
  the `(n_epochs, n_channels, n_times)` array Epochs produce.
- **Silently destroyed the signal** when `filter_ref` was omitted. An unfiltered
  copy of the primary block is perfectly correlated with itself, so every
  canonical correlation is 1.0 and everything is removed. Now raises.
- **`ref_channels` was still required**, then worked around with nested
  `try/except ValueError` on `_resolve_channels` falling back to "use all
  channels". Now genuinely optional in pseudo mode.
- **No validation.** A band edge at or above Nyquist failed inside scipy. Now
  checked at construction.

### Tests

The regression test asserting these parameters raise `TypeError` is replaced
with behavioural tests: band-stop selectivity (20 Hz suppressed to <5%, 2 Hz
preserved >90%), channel-count preservation, and attenuation of a shared
sub-band drift.

55 pass (48 pre-existing, 7 new).

### Status

Draft deliberately. This is being exercised against a replication of
Gonsisko, Ferris & Downey 2023 on the Mind in Motion dual-layer cohort
(ds004625 / ds006095); merging once those numbers confirm it behaves correctly
on real data.