### PR TITLE
Fix/zapline adaptive only selection api

### DIFF
--- a/docs/changes/devel/78.removal.rst
+++ b/docs/changes/devel/78.removal.rst
@@ -1,0 +1,6 @@
+Removed ``min_select`` and ``max_prop_remove`` from the public ``ZapLine``
+constructor because these bounds apply only to adaptive per-segment processing.
+Adaptive ``ZapLine`` continues to use a minimum removal of 1 and a maximum
+removal proportion of 0.2 by default; custom adaptive values can be configured
+through ``adaptive_params["n_remove_params"]``. The corresponding parameters
+remain available on the generic ``DSS`` estimator (Issue #63).

--- a/mne_denoise/zapline/core.py
+++ b/mne_denoise/zapline/core.py
@@ -188,7 +188,12 @@ class ZapLine(DSS):
     - ``max_harmonics`` : int - Maximum number of harmonics to process
     - ``hybrid_fallback`` : bool (default False) - Use notch filter fallback
     - ``min_chunk_len`` : float (default 30.0) - Minimum segment length in seconds
-    - ``n_remove_params`` : dict - Parameters for component selection
+    - ``n_remove_params`` : dict
+      Adaptive per-segment component-selection settings:
+      ``sigma`` is the selection threshold (defaults to ``threshold``),
+      ``min_remove`` is the minimum number of components removed when an
+      artifact is present (defaults to 1), and ``max_prop`` is the maximum
+      proportion of channels removed (defaults to 0.2)
     - ``qa_params`` : dict - Parameters for QA (max_sigma, min_sigma)
 
     Examples
@@ -209,7 +214,12 @@ class ZapLine(DSS):
 
     Adaptive mode (ZapLine-plus):
 
-    >>> zapline = ZapLine(sfreq=1000, line_freq=None, adaptive=True)
+    >>> zapline = ZapLine(
+    ...     sfreq=1000,
+    ...     line_freq=None,
+    ...     adaptive=True,
+    ...     adaptive_params={"n_remove_params": {"min_remove": 1, "max_prop": 0.2}},
+    ... )
     >>> cleaned = zapline.fit_transform(epochs)  # Auto-detects noise frequencies
 
     References
@@ -238,8 +248,6 @@ class ZapLine(DSS):
         adaptive_params: dict | None = None,
         segmenter=None,
         crossfade: float = 0.0,
-        max_prop_remove: float | None = 0.2,
-        min_select: int = 1,
         whiten: bool = False,
         noise_cov=None,
         verbose: bool | str | int | None = None,
@@ -281,8 +289,8 @@ class ZapLine(DSS):
             adaptive=adaptive,
             segmenter=segmenter,
             crossfade=crossfade,
-            max_prop_remove=max_prop_remove,
-            min_select=min_select,
+            max_prop_remove=0.2,
+            min_select=1,
             component_action="subtract",
             n_select=n_select,
             selection_threshold=threshold,

--- a/tests/test_zapline_core.py
+++ b/tests/test_zapline_core.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from unittest.mock import patch
 
 import mne
@@ -1087,19 +1088,6 @@ def test_adaptive_is_inherited_from_dss():
     assert "adaptive" in DSS(bias=lambda x: x).get_params()
     assert "segmented" not in ZapLine(sfreq=500.0).get_params()
     assert ZapLine(sfreq=500.0, adaptive=True).adaptive is True
-
-
-def test_adaptive_is_settable_through_sklearn_api():
-    """adaptive/segmenter/min_select are real params, so clone() works."""
-    from sklearn.base import clone
-
-    zap = ZapLine(sfreq=500.0, line_freq=60.0, adaptive=True, min_select=2)
-    params = zap.get_params()
-    assert {"adaptive", "segmenter", "min_select", "max_prop_remove"} <= set(params)
-    assert clone(zap).min_select == 2
-
-    zap.set_params(adaptive=False)
-    assert zap.adaptive is False
 
 
 def test_process_segment_without_target_frequency_raises():

--- a/tests/test_zapline_core.py
+++ b/tests/test_zapline_core.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import inspect
 from unittest.mock import patch
 
 import mne


### PR DESCRIPTION
# Pull Request
second part and closes #63 removing the confusing adaptive zapline (carried from DSS which has adaptive part also) params from zapline (which is based on DSS).