### PR TITLE
Refactor/mne reuse

### DIFF
--- a/mne_denoise/_data.py
+++ b/mne_denoise/_data.py
@@ -107,12 +107,11 @@ def _resolve_mne_picks(
 ) -> np.ndarray | None:
     """Resolve the channel-selection policy for an MNE instance."""
     if ch_names is not None:
-        missing = [ch for ch in ch_names if ch not in inst.ch_names]
-        if missing:
-            raise ValueError(
-                f"Input MNE object is missing required channels: {missing[:5]}"
-            )
-        return np.array([inst.ch_names.index(ch) for ch in ch_names])
+        return _mne.mne.pick_channels(
+            inst.ch_names,
+            include=ch_names,
+            ordered=True,
+        )
 
     if auto_pick == "data":
         picks = _mne.mne.pick_types(

--- a/mne_denoise/_data.py
+++ b/mne_denoise/_data.py
@@ -27,53 +27,17 @@ def _get_homogeneous_picks(
     if not isinstance(inst, mne_types):
         return None
 
-    ch_types = inst.get_channel_types()
-    pick_specs = [
-        (
-            "mag",
-            {
-                "meg": "mag",
-                "eeg": False,
-                "ref_meg": False,
-                "stim": False,
-                "misc": False,
-            },
-        ),
-        (
-            "grad",
-            {
-                "meg": "grad",
-                "eeg": False,
-                "ref_meg": False,
-                "stim": False,
-                "misc": False,
-            },
-        ),
-        (
-            "eeg",
-            {
-                "meg": False,
-                "eeg": True,
-                "ref_meg": False,
-                "stim": False,
-                "misc": False,
-            },
-        ),
+    indices_by_type = _mne.mne.channel_indices_by_type(inst.info, exclude=())
+    priority = ("mag", "grad", "eeg")
+    present_types = [
+        ch_type for ch_type in priority if len(indices_by_type[ch_type]) > 0
     ]
-
-    present_types = []
-    best_picks = None
-    best_type = None
-
-    for ch_type, pick_kws in pick_specs:
-        if ch_type not in ch_types:
-            continue
-        picks = _mne.mne.pick_types(inst.info, exclude=(), **pick_kws)
-        if len(picks) > 0:
-            present_types.append(ch_type)
-            if best_picks is None:
-                best_picks = np.asarray(picks, dtype=int)
-                best_type = ch_type
+    best_type = present_types[0] if present_types else None
+    best_picks = (
+        np.asarray(indices_by_type[best_type], dtype=int)
+        if best_type is not None
+        else None
+    )
 
     if len(present_types) > 1:
         msg = (
@@ -141,9 +105,14 @@ def _resolve_mne_picks(
         if picks is None
         else np.asarray(picks, dtype=int)
     )
-    bads = set(inst.info["bads"])
+    candidate_names = [inst.ch_names[pick] for pick in candidate_picks]
     picks = np.asarray(
-        [pick for pick in candidate_picks if inst.ch_names[pick] not in bads],
+        _mne.mne.pick_channels(
+            inst.ch_names,
+            include=candidate_names,
+            exclude=inst.info["bads"],
+            ordered=True,
+        ),
         dtype=int,
     )
     if picks.size == 0:

--- a/mne_denoise/_leadfield.py
+++ b/mne_denoise/_leadfield.py
@@ -166,38 +166,6 @@ def _validate_leadfield(
     return leadfield
 
 
-def _forward_gain(forward: mne.Forward) -> np.ndarray:
-    """Extract and validate the gain matrix of a forward solution."""
-    return _validate_leadfield(
-        forward["sol"]["data"], what="The supplied forward gain matrix"
-    )
-
-
-def _leadfield_from_forward(forward: mne.Forward, info: mne.Info) -> np.ndarray:
-    """Extract an average-referenced lead field from a user forward solution.
-
-    The forward's rows are reordered to match ``info``'s channel order, so a
-    forward computed elsewhere (with its own channel ordering) lines up with
-    the data being cleaned.
-    """
-    gain = _forward_gain(forward)
-    row_names = list(forward["sol"]["row_names"])
-    if len(row_names) != gain.shape[0]:
-        raise ValueError(
-            "The supplied forward has a different number of row names and "
-            "gain-matrix rows."
-        )
-    wanted = list(info["ch_names"])
-    missing = [ch for ch in wanted if ch not in row_names]
-    if missing:
-        raise ValueError(
-            "The supplied forward model is missing channels present in the data: "
-            f"{missing[:5]}{'...' if len(missing) > 5 else ''}."
-        )
-    idx = [row_names.index(ch) for ch in wanted]
-    return _average_reference(gain[idx])
-
-
 def fibonacci_sphere(n_points: int) -> np.ndarray:
     """Generate unit vectors quasi-uniformly covering the sphere.
 
@@ -411,12 +379,27 @@ def resolve_leadfield(
         _mne.require_mne("MNE lead-field resolution")
         info = inst.copy().pick(ch_names).info
         if forward is not None:
-            return _leadfield_from_forward(forward, info)
+            _validate_leadfield(
+                forward["sol"]["data"], what="The supplied forward gain matrix"
+            )
+            picked_forward = _mne.mne.pick_channels_forward(
+                forward,
+                include=info["ch_names"],
+                ordered=True,
+                copy=True,
+            )
+            gain = _validate_leadfield(
+                picked_forward["sol"]["data"],
+                what="The supplied forward gain matrix",
+            )
+            return _average_reference(gain)
         return make_spherical_leadfield(
             info, n_dipoles=n_dipoles, head_model=head_model
         )
     if forward is not None:
-        gain = _forward_gain(forward)
+        gain = _validate_leadfield(
+            forward["sol"]["data"], what="The supplied forward gain matrix"
+        )
         if gain.shape[0] != n_channels:
             raise ValueError(
                 "For array input, the forward must have the same number of "

--- a/mne_denoise/dss/_whitening.py
+++ b/mne_denoise/dss/_whitening.py
@@ -297,7 +297,11 @@ def compute_mne_sensor_whitener(
     scales = np.ones(n_channels, dtype=float)
     if info is not None and ch_names is not None:
         _mne.require_mne("DSS MNE sensor whitening")
-        indices = [info["ch_names"].index(name) for name in ch_names]
+        indices = _mne.mne.pick_channels(
+            info["ch_names"],
+            include=ch_names,
+            ordered=True,
+        )
         picked_info = _mne.mne.pick_info(info, indices)
         for picks in _mne.mne.channel_indices_by_type(picked_info, exclude=()).values():
             if len(picks):

--- a/mne_denoise/icanclean.py
+++ b/mne_denoise/icanclean.py
@@ -1305,8 +1305,10 @@ class ICanClean(BaseEstimator, TransformerMixin):
             # from the primary channels in _build_reference_block.
             if self.primary_channels is not None:
                 if ch_names is not None and isinstance(self.primary_channels[0], str):
-                    primary_idx = np.array(
-                        [ch_names.index(ch) for ch in self.primary_channels], dtype=int
+                    primary_idx = _mne.mne.pick_channels(
+                        ch_names,
+                        include=list(self.primary_channels),
+                        ordered=True,
                     )
                 else:
                     primary_idx = np.asarray(self.primary_channels, dtype=int)
@@ -1318,9 +1320,10 @@ class ICanClean(BaseEstimator, TransformerMixin):
             return primary_idx, np.array([], dtype=int)
 
         if ch_names is not None and isinstance(self.ref_channels[0], str):
-            ref_idx = np.array(
-                [ch_names.index(ch) for ch in self.ref_channels],
-                dtype=int,
+            ref_idx = _mne.mne.pick_channels(
+                ch_names,
+                include=list(self.ref_channels),
+                ordered=True,
             )
             ref_names = list(self.ref_channels)
         else:
@@ -1331,9 +1334,10 @@ class ICanClean(BaseEstimator, TransformerMixin):
 
         if self.primary_channels is not None:
             if ch_names is not None and isinstance(self.primary_channels[0], str):
-                primary_idx = np.array(
-                    [ch_names.index(ch) for ch in self.primary_channels],
-                    dtype=int,
+                primary_idx = _mne.mne.pick_channels(
+                    ch_names,
+                    include=list(self.primary_channels),
+                    ordered=True,
                 )
                 primary_names = list(self.primary_channels)
             else:

--- a/tests/test_bss_cca.py
+++ b/tests/test_bss_cca.py
@@ -842,7 +842,7 @@ def test_mne_channel_names_must_match_fit(muscle_data):
         verbose=False,
     )
     estimator = BSSCCA(n_remove=3).fit(train)
-    with pytest.raises(ValueError, match="missing required channels"):
+    with pytest.raises(ValueError, match="Missing channels"):
         estimator.transform(renamed)
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -174,18 +174,65 @@ def test_extract_data_from_mne_list_input():
 
 
 def test_auto_pick_single_type():
-    # Only grad and eog
+    # Only grad among data, with unsupported/non-target channels present.
     info = mne.create_info(
-        ch_names=["grad1", "grad2", "eog1"],
+        ch_names=["stim1", "grad1", "eog1", "grad2", "misc1"],
         sfreq=100.0,
-        ch_types=["grad", "grad", "eog"],
+        ch_types=["stim", "grad", "eog", "grad", "misc"],
     )
-    raw = mne.io.RawArray(np.random.randn(3, 100), info)
+    raw = mne.io.RawArray(np.random.randn(5, 100), info)
 
-    # Should return picks for the 2 grad channels, ignoring EOG
+    # Should return picks for the grad channels, ignoring non-target channels.
     picks = _get_homogeneous_picks(raw)
     assert len(picks) == 2
-    np.testing.assert_array_equal(picks, [0, 1])
+    np.testing.assert_array_equal(picks, [1, 3])
+
+
+def test_auto_pick_priority_is_mag_grad_eeg():
+    info = mne.create_info(
+        ch_names=["eeg1", "mag1", "grad1", "mag2", "eeg2"],
+        sfreq=100.0,
+        ch_types=["eeg", "mag", "grad", "mag", "eeg"],
+    )
+    raw = mne.io.RawArray(np.random.randn(5, 100), info)
+
+    with pytest.warns(UserWarning, match="Found multiple data channel types"):
+        picks = _get_homogeneous_picks(raw)
+
+    np.testing.assert_array_equal(picks, [1, 3])
+
+
+def test_auto_pick_bad_channels_participate_in_type_detection():
+    info = mne.create_info(
+        ch_names=["eeg1", "mag1", "eeg2"],
+        sfreq=100.0,
+        ch_types=["eeg", "mag", "eeg"],
+    )
+    raw = mne.io.RawArray(np.random.randn(3, 100), info)
+    raw.info["bads"] = ["mag1"]
+
+    with pytest.warns(UserWarning, match="Found multiple data channel types"):
+        picks = _get_homogeneous_picks(raw)
+    np.testing.assert_array_equal(picks, [1])
+
+    with pytest.warns(UserWarning, match="Found multiple data channel types"):
+        with pytest.raises(
+            ValueError, match="No good data channels remain after excluding bads"
+        ):
+            extract_data_from_mne(raw, exclude_bads=True)
+
+
+def test_auto_pick_does_not_treat_csd_as_eeg():
+    info = mne.create_info(
+        ch_names=["CSD", "EEG"],
+        sfreq=100.0,
+        ch_types=["csd", "eeg"],
+    )
+    raw = mne.io.RawArray(np.random.randn(2, 100), info)
+
+    picks = _get_homogeneous_picks(raw)
+
+    np.testing.assert_array_equal(picks, [1])
 
 
 def test_auto_pick_mixed_types_warn():

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -115,10 +115,7 @@ def test_extract_data_from_mne_missing_explicit_names():
     info = mne.create_info(["C1", "C2"], 100.0, "eeg")
     raw = mne.io.RawArray(np.ones((2, 100)), info, verbose=False)
 
-    with pytest.raises(
-        ValueError,
-        match=r"Input MNE object is missing required channels: \['C3'\]",
-    ):
+    with pytest.raises(ValueError, match="Missing channels"):
         extract_data_from_mne(raw, ch_names=["C3"])
 
 

--- a/tests/test_icanclean.py
+++ b/tests/test_icanclean.py
@@ -498,7 +498,7 @@ def test_icanclean_mne_raw_cleaning(raw_with_refs):
 
 
 def test_icanclean_mne_explicit_channel_names(rng):
-    """Explicit MNE channel-name selection works."""
+    """Explicit MNE channel-name selection preserves requested order."""
     mne = pytest.importorskip("mne")
     sfreq = 250.0
     n_times = int(sfreq * 6)
@@ -512,17 +512,72 @@ def test_icanclean_mne_explicit_channel_names(rng):
     info = mne.create_info(ch_names, sfreq, ch_types)
     data = rng.standard_normal((n_scalp + n_noise, n_times))
     raw = mne.io.RawArray(data, info, verbose=False)
+    primary_names = [f"1-EEG{i}" for i in reversed(range(n_scalp))]
+    ref_names = [f"2-NSE{i}" for i in reversed(range(n_noise))]
 
     icc = ICanClean(
         sfreq=sfreq,
-        primary_channels=[f"1-EEG{i}" for i in range(n_scalp)],
-        ref_channels=[f"2-NSE{i}" for i in range(n_noise)],
+        primary_channels=primary_names,
+        ref_channels=ref_names,
         verbose=False,
     )
     raw_clean = icc.fit_transform(raw)
     assert isinstance(raw_clean, mne.io.RawArray)
-    assert icc.primary_channels_ == [f"1-EEG{i}" for i in range(n_scalp)]
-    assert icc.ref_channels_ == [f"2-NSE{i}" for i in range(n_noise)]
+    assert icc.primary_channels_ == primary_names
+    assert icc.ref_channels_ == ref_names
+
+
+@pytest.mark.parametrize(
+    ("primary_channels", "ref_channels"),
+    [
+        (["MISSING"], ["2-NSE0"]),
+        (["1-EEG0"], ["MISSING"]),
+    ],
+)
+def test_icanclean_mne_missing_named_channel_raises(
+    rng, primary_channels, ref_channels
+):
+    """MNE named channel resolution reports missing primary or reference names."""
+    mne = pytest.importorskip("mne")
+    info = mne.create_info(
+        ["1-EEG0", "1-EEG1", "2-NSE0", "2-NSE1"],
+        100.0,
+        ["eeg", "eeg", "eeg", "eeg"],
+    )
+    raw = mne.io.RawArray(rng.standard_normal((4, 200)), info, verbose=False)
+    icc = ICanClean(
+        sfreq=100.0,
+        primary_channels=primary_channels,
+        ref_channels=ref_channels,
+        verbose=False,
+    )
+
+    with pytest.raises(ValueError, match="Missing channels"):
+        icc.fit_transform(raw)
+
+
+def test_icanclean_mne_integer_channel_indices_remain_index_based(rng):
+    """Integer MNE channel specifications retain their existing semantics."""
+    mne = pytest.importorskip("mne")
+    info = mne.create_info(
+        ["P0", "P1", "R0", "R1"],
+        100.0,
+        ["eeg"] * 4,
+    )
+    raw = mne.io.RawArray(rng.standard_normal((4, 200)), info, verbose=False)
+    icc = ICanClean(
+        sfreq=100.0,
+        primary_channels=[1, 0],
+        ref_channels=[3, 2],
+        verbose=False,
+    )
+
+    primary_idx, ref_idx = icc._resolve_channels(raw.get_data(), raw)
+
+    np.testing.assert_array_equal(primary_idx, [1, 0])
+    np.testing.assert_array_equal(ref_idx, [3, 2])
+    assert icc.primary_channels_ == ["P1", "P0"]
+    assert icc.ref_channels_ == ["R1", "R0"]
 
 
 def test_icanclean_mne_artifact_reduction(raw_with_refs):

--- a/tests/test_leadfield.py
+++ b/tests/test_leadfield.py
@@ -200,6 +200,8 @@ def test_resolve_leadfield_builds_sphere_without_forward(eeg_info):
 
 def test_resolve_leadfield_from_forward(eeg_info, forward):
     """An MNE object plus a forward takes the forward, channel-aligned."""
+    gain_before = forward["sol"]["data"].copy()
+    row_names_before = forward["sol"]["row_names"].copy()
     leadfield = resolve_leadfield(
         inst=_raw(eeg_info),
         ch_names=eeg_info["ch_names"],
@@ -209,6 +211,10 @@ def test_resolve_leadfield_from_forward(eeg_info, forward):
     )
     assert leadfield.shape[0] == 24
     assert np.allclose(leadfield.mean(axis=0), 0.0, atol=1e-9)
+    expected = gain_before - gain_before.mean(axis=0, keepdims=True)
+    np.testing.assert_allclose(leadfield, expected)
+    np.testing.assert_array_equal(forward["sol"]["data"], gain_before)
+    assert forward["sol"]["row_names"] == row_names_before
 
 
 def test_resolve_leadfield_aligns_forward_channels(eeg_info, forward):
@@ -218,28 +224,25 @@ def test_resolve_leadfield_aligns_forward_channels(eeg_info, forward):
     flipped_info = mne.create_info(shuffled, 1000.0, "eeg")
     flipped_info.set_montage("standard_1020")
 
-    straight = resolve_leadfield(
-        inst=_raw(eeg_info),
-        ch_names=names,
-        n_channels=24,
-        method="SOUND",
-        forward=forward,
-    )
-    reversed_ = resolve_leadfield(
+    leadfield = resolve_leadfield(
         inst=_raw(flipped_info),
         ch_names=shuffled,
         n_channels=24,
         method="SOUND",
         forward=forward,
     )
-    np.testing.assert_allclose(reversed_, straight[::-1], atol=1e-12)
+    row_names = list(forward["sol"]["row_names"])
+    indices = [row_names.index(ch) for ch in shuffled]
+    expected = forward["sol"]["data"][indices]
+    expected -= expected.mean(axis=0, keepdims=True)
+    np.testing.assert_allclose(leadfield, expected, atol=1e-12)
 
 
 def test_resolve_leadfield_forward_missing_channels_raises(forward):
     ch = mne.channels.make_standard_montage("standard_1020").ch_names[:26]
     info = mne.create_info(ch, 1000.0, "eeg")
     info.set_montage("standard_1020")
-    with pytest.raises(ValueError, match="missing channels"):
+    with pytest.raises(ValueError, match="Missing channels"):
         resolve_leadfield(
             inst=_raw(info),
             ch_names=info["ch_names"],

--- a/tests/test_linear_dss.py
+++ b/tests/test_linear_dss.py
@@ -1060,7 +1060,7 @@ def test_dss_transform_rejects_missing_fitted_channel():
     raw = mne.io.RawArray(rng.standard_normal((3, 1000)), info, verbose=False)
     dss = DSS(bias=lambda data: data, normalize_input=False).fit(raw)
 
-    with pytest.raises(ValueError, match="missing required channels.*EEG2"):
+    with pytest.raises(ValueError, match="Missing channels"):
         dss.transform(raw.copy().drop_channels(["EEG2"]))
 
 

--- a/tests/test_zapline_core.py
+++ b/tests/test_zapline_core.py
@@ -165,7 +165,7 @@ def test_zapline_whiten_processes_mixed_sensor_types(mixed_sensor_raw):
     assert est.filters_.shape[1] == 6
     assert cleaned.ch_names == raw.ch_names
     np.testing.assert_array_equal(cleaned.get_data(picks="stim"), stim_before)
-    with pytest.raises(ValueError, match="missing required channels"):
+    with pytest.raises(ValueError, match="Missing channels"):
         est.transform(raw.copy().drop_channels(["CH0"]))
 
 
@@ -757,9 +757,7 @@ def test_zapline_mne_transform_requires_fitted_channels():
     est = ZapLine(sfreq=sfreq, line_freq=50.0, n_select=1, n_harmonics=1, nfft=400)
     est.fit(raw)
 
-    with pytest.raises(
-        ValueError, match="Input MNE object is missing required channels"
-    ):
+    with pytest.raises(ValueError, match="Missing channels"):
         est.transform(raw.copy().drop_channels(["EEG002"]))
 
 

--- a/tests/utils/test_whitening.py
+++ b/tests/utils/test_whitening.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import mne
 import numpy as np
 import pytest
 
@@ -147,6 +148,65 @@ def test_compute_mne_sensor_whitener_numpy_scaling():
 
     np.testing.assert_allclose(transformed.std(axis=1), 1.0)
     np.testing.assert_allclose(colorer @ whitener, np.eye(3))
+
+
+def test_compute_mne_sensor_whitener_preserves_requested_channel_order():
+    """MNE sensor scaling follows the order supplied with the data."""
+    info = mne.create_info(
+        ["EEG0", "MAG0", "EEG1", "MAG1"],
+        100.0,
+        ["eeg", "mag", "eeg", "mag"],
+    )
+    ch_names = ["MAG1", "EEG0", "MAG0", "EEG1"]
+    base = np.arange(1.0, 101.0)
+    data = np.vstack([base, 2.0 * base, 3.0 * base, 4.0 * base])
+    expected_scales = np.array(
+        [
+            np.std(data[[0, 2]]),
+            np.std(data[[1, 3]]),
+            np.std(data[[0, 2]]),
+            np.std(data[[1, 3]]),
+        ]
+    )
+
+    whitener, colorer = compute_mne_sensor_whitener(
+        data,
+        info=info,
+        ch_names=ch_names,
+    )
+
+    np.testing.assert_allclose(np.diag(whitener), 1.0 / expected_scales)
+    np.testing.assert_allclose(np.diag(colorer), expected_scales)
+    np.testing.assert_allclose(
+        apply_spatial_transform(whitener, data),
+        data / expected_scales[:, None],
+    )
+
+    equivalent_info = mne.create_info(
+        ch_names,
+        100.0,
+        ["mag", "eeg", "mag", "eeg"],
+    )
+    equivalent_whitener, equivalent_colorer = compute_mne_sensor_whitener(
+        data,
+        info=equivalent_info,
+        ch_names=ch_names,
+    )
+    np.testing.assert_allclose(equivalent_whitener, whitener)
+    np.testing.assert_allclose(equivalent_colorer, colorer)
+
+
+def test_compute_mne_sensor_whitener_missing_channel_raises():
+    """Named MNE whitening rejects channels absent from the input Info."""
+    info = mne.create_info(["EEG0", "EEG1"], 100.0, "eeg")
+    data = np.ones((2, 100))
+
+    with pytest.raises(ValueError, match="Missing channels"):
+        compute_mne_sensor_whitener(
+            data,
+            info=info,
+            ch_names=["EEG0", "MISSING"],
+        )
 
 
 def test_compute_mne_sensor_whitener_rejects_nonfinite_data():


### PR DESCRIPTION
## What does this change?

Part of #79.

This PR removes some MNE-specific bookkeeping from `mne-denoise` and delegates it to existing public MNE-Python APIs.

* Use `mne.pick_channels_forward()` to restrict/reorder `Forward` objects instead of manually matching `row_names`.
* Use `mne.pick_channels()` for named channel selection in shared data handling, DSS whitening, and ICanClean.
* Use `mne.channel_indices_by_type()` for automatic channel-type grouping, while keeping the existing `mag > grad > eeg` selection policy in `mne-denoise`.
* Use `mne.pick_channels()` for bad-channel exclusion in the automatic MNE-data path.