### PR TITLE
Maint/package build metadata

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# CODEOWNERS routes reviews; it does not imply legal ownership of repository files.
+* @BabaSanfour @snesmaeili

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff pre-commit
+          python -m pip install --group lint
       - name: Run ruff check
         run: ruff check .
       - name: Run ruff format check
@@ -46,6 +48,8 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
@@ -53,7 +57,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[test]
+          python -m pip install -e . --group test
       - name: Run tests
         run: pytest --cov=mne_denoise --cov-report=xml -v
       - name: Upload coverage to Codecov
@@ -70,6 +74,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
@@ -88,6 +94,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
@@ -95,7 +103,7 @@ jobs:
       - name: Install documentation dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[docs]
+          python -m pip install -e . --group doc
       - name: Restore documentation datasets
         id: docs-data-cache
         uses: actions/cache/restore@v6
@@ -140,3 +148,31 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/_build/html/
           force_orphan: true
+
+  package:
+    name: Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+      - name: Build and validate distributions
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --group build
+          rm -rf dist/
+          python -m build
+          python -m twine check --strict dist/*
+          python scripts/check_dist.py dist
+      - name: Validate installed wheel
+        run: |
+          wheel_test="$RUNNER_TEMP/mne-denoise-wheel-test"
+          python -m venv "$wheel_test"
+          wheel="$(find "$GITHUB_WORKSPACE/dist" -maxdepth 1 -name '*.whl' -print -quit)"
+          "$wheel_test/bin/python" -m pip install "$wheel"
+          cd "$RUNNER_TEMP"
+          "$wheel_test/bin/python" "$GITHUB_WORKSPACE/scripts/check_base_install.py"
+          "$wheel_test/bin/python" -m pip check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -23,13 +25,13 @@ jobs:
       - name: Install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build twine
+          python -m pip install --group build
 
       - name: Build package
         run: python -m build
 
       - name: Check package
-        run: twine check dist/*
+        run: python -m twine check --strict dist/*
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,8 +63,8 @@ source .venv/bin/activate
 # Upgrade pip
 python -m pip install --upgrade pip
 
-# Install in editable mode with all dev dependencies
-pip install -e ".[dev,docs]"
+# Install in editable mode with the development dependency group
+python -m pip install -e . --group dev
 
 # Install pre-commit hooks
 pre-commit install
@@ -78,7 +78,8 @@ conda create -n mne-denoise python=3.12
 conda activate mne-denoise
 
 # Install in editable mode
-pip install -e ".[dev,docs]"
+python -m pip install --upgrade pip
+python -m pip install -e . --group dev
 pre-commit install
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ pip install "mne-denoise[mne,viz,progress]"
 ```bash
 git clone https://github.com/mne-tools/mne-denoise.git
 cd mne-denoise
-pip install -e ".[dev]"
+python -m pip install --upgrade pip
+python -m pip install -e . --group dev
 ```
 
 ## Quick Start
@@ -195,7 +196,8 @@ We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guid
 # Development setup
 git clone https://github.com/<your-username>/mne-denoise.git
 cd mne-denoise
-pip install -e ".[dev,docs]"
+python -m pip install --upgrade pip
+python -m pip install -e . --group dev
 pre-commit install
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,21 +1,19 @@
 # Release checklist
 
-This project uses manual versioning in `pyproject.toml`.
+Package versions are derived from Git tags via hatch-vcs.
 
 ## 1. Prepare Release
 
 - [ ] **Update Dependencies**:
     - Check for dependency updates.
-    - Run `pip install .[dev,test,docs]` to ensure environment is fresh.
+    - Run `python -m pip install --upgrade pip` and `python -m pip install -e . --group dev` to ensure environment is fresh.
 - [ ] **Run Checks**:
     - [ ] `ruff check .`
     - [ ] `ruff format .`
     - [ ] `pytest` (ensure all pass)
     - [ ] `make -C docs html` (ensure no warnings)
-- [ ] **Bump Version**:
-    - Update `version` in `pyproject.toml` (e.g., `0.0.1`).
+- [ ] **Update Changelog**:
     - Update `CHANGELOG.md` with release date and summary.
-    - Commit changes: `git commit -am "Bump version to X.Y.Z"`
 
 ## 2. Tag and Publish (GitHub)
 
@@ -33,9 +31,6 @@ This project uses manual versioning in `pyproject.toml`.
 
 ## 4. Post-Release Maintenance
 
-- [ ] **Set Next Version**:
-    - Update `pyproject.toml` to next dev version (e.g., `0.1.0.dev0`).
-    - Commit and push: `git commit -am "Back to dev" && git push upstream main`
 - [ ] **Conda-Forge**:
     - Wait for the regro-cf-autotick-bot to open a PR on the feedstock.
     - Merge the PR to update the conda package.

--- a/docs/changes/devel/96.misc.rst
+++ b/docs/changes/devel/96.misc.rst
@@ -1,0 +1,2 @@
+Package builds now use Hatchling with Git-derived versioning and modern
+distribution metadata.

--- a/docs/changes/devel/96.removal.rst
+++ b/docs/changes/devel/96.removal.rst
@@ -1,0 +1,3 @@
+Development-only ``test``, ``docs``, ``dev``, and ``all`` extras were replaced
+by standardized dependency groups. The user-facing ``mne``, ``viz``, and
+``progress`` extras are unchanged.

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -17,11 +17,13 @@ The example below works with NumPy arrays. To use MNE-Python ``Raw``,
 
    pip install "mne-denoise[mne]"
 
-For development work, clone the repository and install the optional extras:
+For development work, clone the repository and install the development
+dependency group:
 
 .. code-block:: console
 
-   pip install -e ".[dev,docs]"
+   python -m pip install --upgrade pip
+   python -m pip install -e . --group dev
    pre-commit install
 
 Basic usage

--- a/mne_denoise/__init__.py
+++ b/mne_denoise/__init__.py
@@ -1,6 +1,8 @@
 """Artifact removal and signal denoising for EEG and MEG."""
 
 from importlib import import_module
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _distribution_version
 
 from . import (
     asr,
@@ -20,7 +22,10 @@ from . import (
 from ._covariance import compute_covariance
 from .overcorrection import quantify_overcorrection
 
-__version__ = "0.0.1"
+try:
+    __version__ = _distribution_version("mne-denoise")
+except PackageNotFoundError:
+    __version__ = "0.0.0"
 
 
 def __getattr__(name: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,15 @@
 [build-system]
-requires = ["setuptools>=64", "wheel"]
-build-backend = "setuptools.build_meta"
+build-backend = "hatchling.build"
+requires = ["hatch-vcs", "hatchling >= 1.27"]
 
 [project]
 name = "mne-denoise"
-version = "0.0.1"
+dynamic = ["version"]
 description = "Artifact removal and signal denoising for EEG and MEG."
 readme = "README.md"
 requires-python = ">=3.11"
-license = { file = "LICENSE" }
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 authors = [
   { name = "Sina Esmaeili", email = "sina.esmaeili@umontreal.ca" },
   { name = "Hamza Abdelhedi", email = "hamza.abdelhedi@umontreal.ca" },
@@ -18,30 +19,29 @@ maintainers = [
   { name = "Hamza Abdelhedi", email = "hamza.abdelhedi@umontreal.ca" },
 ]
 keywords = [
-  "mne",
-  "eeg",
-  "meg",
+  "artifact-removal",
+  "asr",
   "denoising",
   "dss",
-  "zapline",
+  "eeg",
+  "meg",
+  "mne",
   "neuroscience",
-  "electrophysiology",
   "signal-processing",
+  "zapline",
 ]
 classifiers = [
   "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering",
-  "Topic :: Scientific/Engineering :: Bio-Informatics",
-  "Topic :: Scientific/Engineering :: Medical Science Apps.",
+  "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
   "numpy>=1.26,<3",
@@ -51,13 +51,24 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/mne-tools/mne-denoise"
-Documentation = "https://mne.tools/mne-denoise/"
-Repository = "https://github.com/mne-tools/mne-denoise"
-Issues = "https://github.com/mne-tools/mne-denoise/issues"
+"Bug Tracker" = "https://github.com/mne-tools/mne-denoise/issues"
 Changelog = "https://github.com/mne-tools/mne-denoise/blob/main/CHANGELOG.md"
+Documentation = "https://mne.tools/mne-denoise/"
+Homepage = "https://mne.tools/mne-denoise/"
+"Source Code" = "https://github.com/mne-tools/mne-denoise"
 
 [project.optional-dependencies]
+mne = [
+  "mne>=1.12.1",
+]
+progress = [
+  "tqdm>=4.66",
+]
+viz = [
+  "matplotlib>=3.8",
+]
+
+[dependency-groups]
 test = [
   "pytest>=7.4.0",
   "pytest-cov>=4.1.0",
@@ -68,26 +79,8 @@ test = [
   "seaborn>=0.12",
   "tqdm>=4.66",
 ]
-mne = [
-  "mne>=1.12.1",
-]
-viz = [
-  "matplotlib>=3.8",
-]
-progress = [
-  "tqdm>=4.66",
-]
-dev = [
-  "mne-denoise[test]",
-  "ruff>=0.16.0",
-  "pre-commit>=3.6.0",
-  "mypy>=1.8.0",
-  "build>=1.0.0",
-  "twine>=5.0.0",
-  "types-setuptools",
-  "towncrier",
-]
-docs = [
+
+doc = [
   "mne>=1.12.1",
   "matplotlib>=3.8",
   "numpydoc>=1.6.0",
@@ -98,15 +91,38 @@ docs = [
   "sphinx-gallery>=0.15.0",
   "myst-parser>=2.0.0",
 ]
-all = [
-  "mne-denoise[dev,docs,progress]",
+build = [
+  "build>=1.0.0",
+  "packaging",
+  "twine>=5.0.0",
 ]
 
-[tool.setuptools]
-include-package-data = true
+lint = [
+  "ruff>=0.16.0",
+  "pre-commit>=3.6.0",
+]
 
-[tool.setuptools.packages.find]
-where = [""]
+typecheck = [
+  "mypy>=1.8.0",
+]
+
+changelog = [
+  "towncrier",
+]
+
+dev = [
+  "pip>=25.1",
+  { include-group = "test" },
+  { include-group = "doc" },
+  { include-group = "build" },
+  { include-group = "lint" },
+  { include-group = "typecheck" },
+  { include-group = "changelog" },
+]
+
+[tool.hatch.version]
+source = "vcs"
+raw-options = { version_scheme = "release-branch-semver" }
 
 [tool.ruff]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ dev = [
 
 [tool.hatch.version]
 source = "vcs"
-raw-options = { version_scheme = "release-branch-semver" }
+raw-options = { version_scheme = "guess-next-dev" }
 
 [tool.ruff]
 line-length = 88

--- a/scripts/check_base_install.py
+++ b/scripts/check_base_install.py
@@ -1,5 +1,6 @@
 """Validate the base installation without optional runtime dependencies."""
 
+from importlib.metadata import version
 from importlib.util import find_spec
 
 
@@ -12,6 +13,8 @@ def main() -> None:
 
     import mne_denoise
     from mne_denoise import compute_covariance
+
+    assert mne_denoise.__version__ == version("mne-denoise")
 
     covariance = compute_covariance(np.eye(3))
     assert np.isfinite(covariance).all()

--- a/scripts/check_dist.py
+++ b/scripts/check_dist.py
@@ -1,0 +1,184 @@
+"""Validate the structure and metadata of mne-denoise distributions."""
+
+from __future__ import annotations
+
+import argparse
+import tarfile
+from email.parser import Parser
+from pathlib import Path
+from zipfile import ZipFile
+
+from packaging.requirements import Requirement
+from packaging.utils import parse_wheel_filename
+from packaging.version import Version
+
+CORE_REQUIREMENTS = {"numpy", "scipy", "scikit-learn", "joblib"}
+OPTIONAL_REQUIREMENTS = {
+    "mne": "mne",
+    "progress": "tqdm",
+    "viz": "matplotlib",
+}
+DEVELOPMENT_REQUIREMENTS = {
+    "pytest",
+    "sphinx",
+    "ruff",
+    "pre-commit",
+    "mypy",
+    "build",
+    "twine",
+    "towncrier",
+}
+PUBLISHED_EXTRAS = set(OPTIONAL_REQUIREMENTS)
+REPOSITORY_TREES = {
+    ".github/",
+    "docs/",
+    "examples/",
+    "scripts/",
+    "tests/",
+}
+
+
+def _single_artifact(dist_dir: Path, suffix: str) -> Path:
+    """Return the only distribution artifact with the requested suffix."""
+    artifacts = sorted(
+        path
+        for path in dist_dir.iterdir()
+        if path.is_file() and path.name.endswith(suffix)
+    )
+    assert len(artifacts) == 1, (
+        f"expected exactly one {suffix} artifact in {dist_dir}, found {artifacts}"
+    )
+    return artifacts[0]
+
+
+def _wheel_metadata(archive: ZipFile) -> tuple[str, object]:
+    """Return the wheel metadata member and parsed email metadata."""
+    metadata_members = [
+        name for name in archive.namelist() if name.endswith(".dist-info/METADATA")
+    ]
+    assert len(metadata_members) == 1, (
+        f"expected one wheel METADATA member, found {metadata_members}"
+    )
+    metadata_name = metadata_members[0]
+    metadata = Parser().parsestr(archive.read(metadata_name).decode("utf-8"))
+    return metadata_name, metadata
+
+
+def _check_wheel(wheel: Path) -> None:
+    """Validate wheel contents and core distribution metadata."""
+    project_name, filename_version, _, tags = parse_wheel_filename(wheel.name)
+    assert str(project_name) == "mne-denoise"
+    assert {str(tag) for tag in tags} == {"py3-none-any"}
+
+    with ZipFile(wheel) as archive:
+        names = set(archive.namelist())
+        assert "mne_denoise/__init__.py" in names
+        assert not any(
+            name == tree.rstrip("/") or name.startswith(tree)
+            for name in names
+            for tree in REPOSITORY_TREES
+        )
+        assert all(
+            name.startswith("mne_denoise/") or ".dist-info/" in name for name in names
+        )
+
+        _, metadata = _wheel_metadata(archive)
+        assert metadata["Name"] == "mne-denoise"
+        assert metadata["Requires-Python"] == ">=3.11"
+        assert metadata["License-Expression"] == "BSD-3-Clause"
+        assert "LICENSE" in metadata.get_all("License-File", [])
+
+        extras = set(metadata.get_all("Provides-Extra", []))
+        assert extras == PUBLISHED_EXTRAS, extras
+
+        requirements = [
+            Requirement(value) for value in metadata.get_all("Requires-Dist", [])
+        ]
+        base_requirements = {
+            requirement.name.lower()
+            for requirement in requirements
+            if requirement.marker is None
+        }
+        assert base_requirements >= CORE_REQUIREMENTS, (
+            f"missing base requirements: {CORE_REQUIREMENTS - base_requirements}"
+        )
+
+        for extra, expected_requirement in OPTIONAL_REQUIREMENTS.items():
+            extra_requirements = {
+                requirement.name.lower()
+                for requirement in requirements
+                if requirement.marker is not None
+                and requirement.marker.evaluate({"extra": extra})
+            }
+            assert extra_requirements == {expected_requirement}, (
+                f"unexpected requirements for {extra!r}: {extra_requirements}"
+            )
+
+        leaked_requirements = {
+            requirement.name.lower()
+            for requirement in requirements
+            if requirement.name.lower() in DEVELOPMENT_REQUIREMENTS
+        }
+        assert not leaked_requirements, leaked_requirements
+
+        assert Version(metadata["Version"]) == Version(str(filename_version))
+
+        author_metadata = "\n".join(
+            value
+            for field in ("Author", "Author-email", "Maintainer", "Maintainer-email")
+            for value in metadata.get_all(field, [])
+        )
+        for author in ("Sina Esmaeili", "Hamza Abdelhedi"):
+            assert author in author_metadata
+
+
+def _check_sdist(sdist: Path) -> None:
+    """Validate the minimum source files included in the sdist."""
+    with tarfile.open(sdist, mode="r:gz") as archive:
+        names = [member.name.rstrip("/") for member in archive.getmembers()]
+    roots = {name.split("/", 1)[0] for name in names if name}
+    assert len(roots) == 1, f"sdist has unexpected top-level roots: {roots}"
+    root = next(iter(roots))
+    prefix = f"{root}/"
+    relative_names = {
+        name.removeprefix(prefix) for name in names if name.startswith(prefix)
+    }
+
+    required_files = {
+        "pyproject.toml",
+        "README.md",
+        "LICENSE",
+        "mne_denoise/__init__.py",
+    }
+    assert required_files <= relative_names, (
+        f"sdist is missing: {required_files - relative_names}"
+    )
+    assert any(name == "tests" or name.startswith("tests/") for name in relative_names)
+
+
+def check_distribution(dist_dir: Path) -> None:
+    """Validate the wheel and source distribution in ``dist_dir``."""
+    assert dist_dir.is_dir(), f"distribution directory does not exist: {dist_dir}"
+    wheel = _single_artifact(dist_dir, ".whl")
+    sdist = _single_artifact(dist_dir, ".tar.gz")
+    _check_wheel(wheel)
+    _check_sdist(sdist)
+    print(f"Validated {wheel.name} and {sdist.name}")
+
+
+def main() -> None:
+    """Parse the distribution directory and run all checks."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "dist_dir",
+        nargs="?",
+        type=Path,
+        default=Path("dist"),
+        help="directory containing exactly one wheel and one sdist (default: dist)",
+    )
+    args = parser.parse_args()
+    check_distribution(args.dist_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_dist.py
+++ b/scripts/check_dist.py
@@ -99,8 +99,8 @@ def _check_wheel(wheel: Path) -> None:
             for requirement in requirements
             if requirement.marker is None
         }
-        assert base_requirements >= CORE_REQUIREMENTS, (
-            f"missing base requirements: {CORE_REQUIREMENTS - base_requirements}"
+        assert base_requirements == CORE_REQUIREMENTS, (
+            f"unexpected base requirements: {base_requirements}"
         )
 
         for extra, expected_requirement in OPTIONAL_REQUIREMENTS.items():


### PR DESCRIPTION
## Summary

Part of #79.

Modernizes the packaging and build infrastructure for `mne-denoise`.

* switches the build backend from setuptools to Hatchling with `hatch-vcs`;
* derives package versions from Git tags, targeting the `0.0.2` release line;
* adopts modern PEP 639 license metadata;
* moves development/test/docs dependencies to PEP 735 dependency groups while keeping only `mne`, `viz`, and `progress` as user-facing extras;
* adds repository-wide `CODEOWNERS` for Hamza and Sina;
* adds wheel/sdist validation and clean installed-wheel checks;
* updates CI and release workflows only as required by the packaging changes;
* updates development and release instructions for the new dependency/versioning model.