### PR TITLE
Maint/release infrastructure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,43 +1,137 @@
-name: Publish to PyPI
+name: Release
 
 on:
+  release:
+    types: [published]
   push:
-    tags:
-      - "v*"
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
-  build-n-publish:
-    name: Build and publish to PyPI
+  package:
+    name: Package
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v7
+          persist-credentials: false
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
-
-      - name: Install build tools
+      - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install --group build
+      - name: Validate release tag and checkout
+        id: release
+        if: github.event_name == 'release'
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASE_TAG" != v* ]]; then
+            echo "release tag must start with v: $RELEASE_TAG" >&2
+            exit 1
+          fi
 
-      - name: Build package
-        run: python -m build
+          expected_version="${RELEASE_TAG#v}"
+          canonical_version="$(
+            python - "$expected_version" <<'PY'
+          import sys
 
-      - name: Check package
-        run: python -m twine check --strict dist/*
+          from packaging.version import InvalidVersion, Version
 
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+          value = sys.argv[1]
+          try:
+              parsed = Version(value)
+          except InvalidVersion as error:
+              raise SystemExit(f"invalid release version {value!r}: {error}") from error
+          if str(parsed) != value:
+              raise SystemExit(
+                  f"release version {value!r} is not canonical PEP 440 spelling; "
+                  f"use {parsed}"
+              )
+          print(parsed)
+          PY
+          )"
+          if ! git rev-parse --verify --quiet "refs/tags/$RELEASE_TAG" >/dev/null; then
+            echo "release tag is not available in the checkout: $RELEASE_TAG" >&2
+            exit 1
+          fi
+          head_sha="$(git rev-parse HEAD)"
+          tag_sha="$(git rev-parse "${RELEASE_TAG}^{commit}")"
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+          echo "release tag: $RELEASE_TAG"
+          echo "tagged commit SHA: $tag_sha"
+          echo "checkout HEAD SHA: $head_sha"
+          echo "tags pointing at HEAD:"
+          git tag --points-at HEAD
+          echo "derived package version: $canonical_version"
+          if [[ "$tag_sha" != "$head_sha" ]]; then
+            echo "release tag $RELEASE_TAG does not point to checkout HEAD" >&2
+            exit 1
+          fi
+          echo "expected_version=$canonical_version" >> "$GITHUB_OUTPUT"
+      - name: Build distribution artifacts
+        run: |
+          rm -rf dist/
+          python -m build
+      - name: Validate distribution artifacts
+        env:
+          EXPECTED_VERSION: ${{ steps.release.outputs.expected_version }}
+        run: |
+          set -euo pipefail
+          python -m twine check --strict dist/*
+          if [[ -n "$EXPECTED_VERSION" ]]; then
+            python scripts/check_dist.py dist --expected-version "$EXPECTED_VERSION"
+          else
+            python scripts/check_dist.py dist
+          fi
+      - name: Validate installed wheel
+        run: |
+          set -euo pipefail
+          wheel_test="$RUNNER_TEMP/mne-denoise-wheel-test"
+          python -m venv "$wheel_test"
+          wheel="$(find "$GITHUB_WORKSPACE/dist" -maxdepth 1 -name '*.whl' -print -quit)"
+          test -n "$wheel"
+          "$wheel_test/bin/python" -m pip install "$wheel"
+          cd "$RUNNER_TEMP"
+          "$wheel_test/bin/python" "$GITHUB_WORKSPACE/scripts/check_base_install.py"
+          "$wheel_test/bin/python" -m pip check
+      - name: Upload release distributions
+        uses: actions/upload-artifact@v7
         with:
-          generate_release_notes: true
-          files: dist/*
+          name: release-dists
+          path: dist/
+          if-no-files-found: error
+          retention-days: 14
+
+  publish:
+    name: Publish to PyPI
+    needs: package
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mne-denoise
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: release-dists
+          path: dist/
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          print-hash: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,40 +80,6 @@ jobs:
               print(package, version(package))
           PY
 
-  package:
-    name: Package
-    if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - uses: actions/setup-python@v7
-        with:
-          python-version: "3.11"
-      - name: Build and validate distributions
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install --group build
-          rm -rf dist/
-          python -m build
-          python -m twine check --strict dist/*
-          python scripts/check_dist.py dist
-      - name: Validate installed wheel
-        run: |
-          wheel_test="$RUNNER_TEMP/mne-denoise-wheel-test"
-          python -m venv "$wheel_test"
-          wheel="$(find "$GITHUB_WORKSPACE/dist" -maxdepth 1 -name '*.whl' -print -quit)"
-          "$wheel_test/bin/python" -m pip install "$wheel"
-          cd "$RUNNER_TEMP"
-          "$wheel_test/bin/python" "$GITHUB_WORKSPACE/scripts/check_base_install.py"
-          "$wheel_test/bin/python" -m pip check
-
   minimum:
     name: Minimum dependencies
     if: github.event_name != 'schedule'

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,36 +1,227 @@
-# Release checklist
+# Releasing mne-denoise
 
-Package versions are derived from Git tags via hatch-vcs.
+`mne-denoise` gets its package version from Git tags through `hatch-vcs`. The
+canonical release tag is `vX.Y.Z`, for example `v0.0.2` or `v0.0.2rc1`.
 
-## 1. Prepare Release
+Pushing a tag is safe: a tag push alone does **not** publish to PyPI. The
+release workflow starts publishing only when the corresponding GitHub Release
+is deliberately published.
 
-- [ ] **Update Dependencies**:
-    - Check for dependency updates.
-    - Run `python -m pip install --upgrade pip` and `python -m pip install -e . --group dev` to ensure environment is fresh.
-- [ ] **Run Checks**:
-    - [ ] `ruff check .`
-    - [ ] `ruff format .`
-    - [ ] `pytest` (ensure all pass)
-    - [ ] `make -C docs html` (ensure no warnings)
-- [ ] **Update Changelog**:
-    - Update `CHANGELOG.md` with release date and summary.
+## Release architecture
 
-## 2. Tag and Publish (GitHub)
+The release workflow (`.github/workflows/release.yml`) runs its read-only
+`Package` job on pull requests to `main`, pushes to `main`, and published
+GitHub Releases. On a published GitHub Release it performs this flow:
 
-- [ ] **Tag Release**:
-    - `git tag vX.Y.Z`
-    - `git push upstream main`
-    - `git push upstream vX.Y.Z`
+```text
+published GitHub Release
+        ↓
+Package: checkout the tagged commit
+        ↓
+python -m build
+        ↓
+twine check + check_dist.py + clean wheel installation
+        ↓
+Actions artifact: release-dists
+        ↓
+Publish to PyPI: download release-dists
+        ↓
+PyPI Trusted Publishing / OIDC
+```
 
-## 3. Verify Release (GitHub & PyPI)
+The wheel and sdist are built once. The PyPI job downloads those exact
+validated files and does not check out the repository or rebuild anything.
+PyPI is the canonical distribution location; package files are not uploaded
+to the GitHub Release.
 
-- [ ] **Verify CI/CD**:
-    - Watch functionality of `ci.yml`.
-    - Watch `release.yml` (triggered by tag).
-    - **PyPI Publishing**: Verify the new version appears on PyPI (automated via Trusted Publishing).
+## Before the release
 
-## 4. Post-Release Maintenance
+1. Ensure `main` is current and clean.
 
-- [ ] **Conda-Forge**:
-    - Wait for the regro-cf-autotick-bot to open a PR on the feedstock.
-    - Merge the PR to update the conda package.
+   ```bash
+   git checkout main
+   git pull --ff-only
+   git status --short
+   ```
+
+2. Confirm that the required Tests and Docs CI checks are green for the
+   release commit.
+
+3. Choose the release version `X.Y.Z`.
+
+4. Build and inspect the Towncrier changelog locally. Install the changelog
+   group if needed, then run:
+
+   ```bash
+   python -m pip install --group changelog
+   towncrier build --version X.Y.Z
+   git diff -- CHANGELOG.md docs/changes/devel/
+   ```
+
+   Review the generated `CHANGELOG.md` and confirm that the intended release
+   fragments were consumed. Commit the changelog before tagging.
+
+5. Run the final local distribution validation:
+
+   ```bash
+   python -m pip install --upgrade pip
+   python -m pip install --group build
+   rm -rf dist/
+   python -m build
+   python -m twine check --strict dist/*
+   python scripts/check_dist.py dist
+   ```
+
+   Plain `python -m build` is intentional: it builds the sdist first and then
+   builds the wheel from the extracted sdist, checking that the sdist is
+   complete. Do not replace it with `python -m build --sdist --wheel`.
+
+## Tag the release
+
+After the release changelog is committed and checks are green, create and push
+the canonical tag:
+
+```bash
+git tag -a vX.Y.Z -m "mne-denoise X.Y.Z"
+git push upstream vX.Y.Z
+```
+
+Use the project repository remote for `upstream` if the local remote has a
+different name. Do not describe this tag push as a publication step. It only
+makes the release commit available for review.
+
+## Create and publish the GitHub Release
+
+Create a draft GitHub Release for exactly the tag that was pushed. This can be
+done in the GitHub UI or with:
+
+```bash
+gh release create vX.Y.Z \
+  --draft \
+  --generate-notes \
+  --title "vX.Y.Z"
+```
+
+Before publishing the draft, review:
+
+- the tag and target commit;
+- the release title; and
+- the generated and manually edited release notes.
+
+Do not upload wheel or sdist files to the GitHub Release. When the draft is
+correct, publish the GitHub Release. That deliberate publication is the only
+release event that starts the PyPI publishing job. CI does not create, edit,
+publish, or attach assets to the GitHub Release.
+
+A draft release may be edited while it is being reviewed. After publication,
+do not move or rewrite its tag or replace the package version in place. If a
+release is incorrect, publish a corrected new version instead.
+
+## PyPI publication
+
+After the GitHub Release is published:
+
+1. `Package` checks out the release tag with full history, validates that the
+   tag is exactly `v<PEP 440 version>`, confirms that `HEAD` is exactly tagged,
+   builds the sdist and wheel, and checks that both artifacts have the expected
+   release version.
+2. The validated wheel and sdist are stored together as the `release-dists`
+   Actions artifact.
+3. `Publish to PyPI` waits for the `pypi` GitHub Environment rules, if any.
+   A required reviewer may approve the deployment.
+4. The job downloads `release-dists` and invokes
+   `pypa/gh-action-pypi-publish@release/v1` with GitHub OIDC. It does not
+   rebuild the package.
+
+The workflow uses no PyPI API token or stored upload credentials, and it does
+not call manual `twine upload` or suppress duplicate-publication failures. A
+duplicate publication should fail loudly rather than be silently ignored.
+
+PyPI publishing requires the repository's `pypi` GitHub Environment and the
+corresponding PyPI Trusted Publisher configuration to remain aligned with
+`.github/workflows/release.yml`.
+
+The expected Trusted Publisher configuration is:
+
+- owner: `mne-tools`
+- repository: `mne-denoise`
+- workflow: `release.yml`
+- GitHub environment: `pypi`
+
+If the repository, workflow name, organization, or environment changes, update
+the Trusted Publisher configuration before the next release. The `pypi`
+Environment should also retain appropriate deployment protections, such as a
+`v*` tag rule, trusted reviewer approval, and prevention of self-review when
+operationally feasible.
+
+The workflow's `environment: pypi` and `id-token: write` permission do not by
+themselves configure the external PyPI publisher or GitHub Environment
+protections; those settings must remain configured in their respective
+services.
+
+## Verify the release
+
+After PyPI publication, install the released version in a clean environment:
+
+```bash
+python -m venv /tmp/mne-denoise-release-check
+/tmp/mne-denoise-release-check/bin/python -m pip install --upgrade pip
+/tmp/mne-denoise-release-check/bin/python -m pip install "mne-denoise==X.Y.Z"
+```
+
+Then verify the installed metadata and package version agree:
+
+```bash
+/tmp/mne-denoise-release-check/bin/python - <<'PY'
+from importlib.metadata import version
+import mne_denoise
+
+print(version("mne-denoise"))
+print(mne_denoise.__version__)
+
+assert version("mne-denoise") == mne_denoise.__version__
+PY
+```
+
+Also verify on PyPI that there is exactly one sdist and one `py3-none-any`
+wheel for `X.Y.Z`, and that:
+
+- the upload reports Trusted Publishing as enabled;
+- provenance/attestation is present;
+- the provenance identifies `mne-tools/mne-denoise`, `release.yml`, the
+  `release` trigger, `refs/tags/vX.Y.Z`, and the tagged source commit; and
+- the GitHub Release exists for the same tag and target commit.
+
+The PyPA publishing action's provenance attestations remain enabled by
+default. Actual PyPI provenance can only be checked after a real publication;
+ordinary pull request CI cannot exercise production OIDC.
+
+## Conda-forge
+
+The conda-forge package is maintained in
+`conda-forge/mne-denoise-feedstock`, not in this repository's release
+workflow.
+
+After a new version is published to PyPI, the conda-forge version-update bot
+opens a feedstock pull request with the new source version and hash. Feedstock
+CI validates the recipe and, when the feedstock's bot automation is enabled, a
+passing version-update pull request may merge automatically and publish the
+new conda-forge package.
+
+Before relying on automatic merging, ensure that the feedstock recipe reflects
+the current build system, Python support, runtime dependency contract, and
+chosen policy for optional integrations.
+
+## Versioning after a release
+
+There is no post-release version-bump commit. Do not set a version to
+`X.Y.Z`, change it back to `X.Y.Z.dev0`, or add a manual version file. With
+`hatch-vcs`, tagged builds use the tag version and subsequent untagged `main`
+builds automatically derive the next development version from Git history.
+
+## Repository release settings
+
+GitHub immutable releases are compatible with this workflow because CI does
+not modify a published release or attach package assets after publication.
+Enable immutable releases in repository settings once the release process is
+configured; this workflow does not change that setting.

--- a/docs/changes/devel/98.misc.rst
+++ b/docs/changes/devel/98.misc.rst
@@ -1,0 +1,2 @@
+Release distributions are now built and validated once, then published to
+PyPI from the exact validated artifacts using Trusted Publishing.

--- a/scripts/check_dist.py
+++ b/scripts/check_dist.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from zipfile import ZipFile
 
 from packaging.requirements import Requirement
-from packaging.utils import parse_wheel_filename
+from packaging.utils import parse_sdist_filename, parse_wheel_filename
 from packaging.version import Version
 
 CORE_REQUIREMENTS = {"numpy", "scipy", "scikit-learn", "joblib"}
@@ -64,7 +64,7 @@ def _wheel_metadata(archive: ZipFile) -> tuple[str, object]:
     return metadata_name, metadata
 
 
-def _check_wheel(wheel: Path) -> None:
+def _check_wheel(wheel: Path) -> Version:
     """Validate wheel contents and core distribution metadata."""
     project_name, filename_version, _, tags = parse_wheel_filename(wheel.name)
     assert str(project_name) == "mne-denoise"
@@ -131,14 +131,36 @@ def _check_wheel(wheel: Path) -> None:
         for author in ("Sina Esmaeili", "Hamza Abdelhedi"):
             assert author in author_metadata
 
+    return filename_version
 
-def _check_sdist(sdist: Path) -> None:
+
+def _check_sdist(sdist: Path) -> Version:
     """Validate the minimum source files included in the sdist."""
+    project_name, filename_version = parse_sdist_filename(sdist.name)
+    assert str(project_name) == "mne-denoise"
+
     with tarfile.open(sdist, mode="r:gz") as archive:
-        names = [member.name.rstrip("/") for member in archive.getmembers()]
-    roots = {name.split("/", 1)[0] for name in names if name}
-    assert len(roots) == 1, f"sdist has unexpected top-level roots: {roots}"
-    root = next(iter(roots))
+        members = archive.getmembers()
+        names = [member.name.rstrip("/") for member in members]
+        roots = {name.split("/", 1)[0] for name in names if name}
+        assert len(roots) == 1, f"sdist has unexpected top-level roots: {roots}"
+        root = next(iter(roots))
+
+        pkg_info_members = [
+            member for member in members if member.name == f"{root}/PKG-INFO"
+        ]
+        assert len(pkg_info_members) == 1, (
+            f"expected one {root}/PKG-INFO member, found {pkg_info_members}"
+        )
+        pkg_info_member = pkg_info_members[0]
+        assert pkg_info_member.isfile(), f"{pkg_info_member.name} is not a regular file"
+        pkg_info_file = archive.extractfile(pkg_info_member)
+        assert pkg_info_file is not None, f"could not read {pkg_info_member.name}"
+        pkg_info = Parser().parsestr(pkg_info_file.read().decode("utf-8"))
+        assert pkg_info["Name"] == "mne-denoise"
+        assert pkg_info["Version"] is not None
+        assert Version(pkg_info["Version"]) == filename_version
+
     prefix = f"{root}/"
     relative_names = {
         name.removeprefix(prefix) for name in names if name.startswith(prefix)
@@ -155,14 +177,24 @@ def _check_sdist(sdist: Path) -> None:
     )
     assert any(name == "tests" or name.startswith("tests/") for name in relative_names)
 
+    return filename_version
 
-def check_distribution(dist_dir: Path) -> None:
+
+def check_distribution(dist_dir: Path, expected_version: Version | None = None) -> None:
     """Validate the wheel and source distribution in ``dist_dir``."""
     assert dist_dir.is_dir(), f"distribution directory does not exist: {dist_dir}"
     wheel = _single_artifact(dist_dir, ".whl")
     sdist = _single_artifact(dist_dir, ".tar.gz")
-    _check_wheel(wheel)
-    _check_sdist(sdist)
+    wheel_version = _check_wheel(wheel)
+    sdist_version = _check_sdist(sdist)
+    assert wheel_version == sdist_version, (
+        f"wheel/sdist version mismatch: {wheel.name} has {wheel_version}, "
+        f"{sdist.name} has {sdist_version}"
+    )
+    if expected_version is not None:
+        assert wheel_version == expected_version, (
+            f"expected version {expected_version}, found {wheel_version}"
+        )
     print(f"Validated {wheel.name} and {sdist.name}")
 
 
@@ -176,8 +208,13 @@ def main() -> None:
         default=Path("dist"),
         help="directory containing exactly one wheel and one sdist (default: dist)",
     )
+    parser.add_argument(
+        "--expected-version",
+        type=Version,
+        help="require both artifacts to have this semantic version",
+    )
     args = parser.parse_args()
-    check_distribution(args.dist_dir)
+    check_distribution(args.dist_dir, expected_version=args.expected_version)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Part of #79.

Modernizes the release pipeline to make package publication reproducible and secure.

* builds and validates wheel/sdist artifacts once;
* verifies release tag and package versions agree;
* publishes the exact validated artifacts to PyPI using Trusted Publishing/OIDC;
* separates package validation from publication with least-privilege permissions;
* updates the release documentation for the new workflow.